### PR TITLE
refactor: remove duplicate includes

### DIFF
--- a/EngineService.h
+++ b/EngineService.h
@@ -9,11 +9,9 @@
 #include <QNetworkReply>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QFile>
 #include <QHttpMultiPart>
 #include <QUrlQuery>
 #include <QMessageBox>
-#include <QMap>
 
 /**
  * @struct ResponseStatusInfo


### PR DESCRIPTION
## Summary
- remove duplicate QFile and QMap includes from EngineService.h

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt5" with any of the following names: Qt5Config.cmake, qt5-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b3206f89e0832e8189142476d63295