### PR TITLE
Handle file open errors in EngineService

### DIFF
--- a/EngineService.cpp
+++ b/EngineService.cpp
@@ -20,7 +20,13 @@ QJsonDocument EngineService::startEngine() {return sendPostRequest("/engine/star
 QJsonDocument EngineService::loadEngine(QString filePath) {
     QHttpMultiPart *multiPart = new QHttpMultiPart(QHttpMultiPart::FormDataType);
     QFile *file = new QFile(filePath);
-    file->open(QIODevice::ReadOnly);
+    if (!file->open(QIODevice::ReadOnly)) {
+        qWarning() << "Failed to open file" << filePath << file->errorString();
+        delete file;
+        delete multiPart;
+        return {};
+    }
+    file->setParent(multiPart);
 
     QHttpPart filePart;
     filePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"json_file\"; filename=\"" + file->fileName() + "\""));


### PR DESCRIPTION
## Summary
- Check for `QFile::open` failure when loading engine files
- Assign file object to multipart parent and clean up on error

## Testing
- `./tests/run_tests.sh` *(fails: By not providing "FindQt5.cmake" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b32090084c832eb20ba994cc5a2cd8