### PR TITLE
Log WebSocket errors

### DIFF
--- a/WebsocketService.cpp
+++ b/WebsocketService.cpp
@@ -45,8 +45,9 @@ void WebSocketService::onDisconnected() {
     reconnectTimer->start();
 }
 
-void WebSocketService::onError(QAbstractSocket::SocketError ) {
-  //  qLog() << "WebSocket error occurred:" << socket->errorString();
+void WebSocketService::onError(QAbstractSocket::SocketError error) {
+    qLog() << "WebSocket error occurred:" << socket->errorString()
+           << "(code:" << static_cast<int>(error) << ')';
     if (socket) socket->close();  // Close the socket and attempt reconnection
     reconnectTimer->start();
 }


### PR DESCRIPTION
## Summary
- log WebSocket connection errors including the socket error string and code

## Testing
- `./tests/run_tests.sh` *(fails: Could not find a package configuration file provided by "Qt5")*

------
https://chatgpt.com/codex/tasks/task_e_68b32100c504832e9516135218b3a954