### PR TITLE
Hide root item for enemy and ally compositions

### DIFF
--- a/db_service/ScenarioParser.h
+++ b/db_service/ScenarioParser.h
@@ -136,8 +136,10 @@ private:
     QTreeWidgetItem* filesItem          = nullptr;
     QTreeWidgetItem* interactionItems   = nullptr;
     QTreeWidgetItem* featuresItem      = nullptr;
+    QList<QTreeWidgetItem*>             m_topLevelObjects;
 
     QString getTreeItemObjectNameByType(const TypeView &typeView);
+    void moveObjectItemsToRoot(bool toRoot);
 
 
 };


### PR DESCRIPTION
## Summary
- Allow enemy and ally composition views to display objects without a root header
- Track object items moved to the root and restore them when switching views

## Testing
- `tests/run_tests.sh` *(fails: Could not find Qt5 package)*
- `apt-get install -y qtbase5-dev` *(fails: Unable to locate package qtbase5-dev)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f58c92c832e8ab07cc086b2726f