### PR TITLE
Add properties dialog for scenario items

### DIFF
--- a/db_service/ScenarioEditor.cpp
+++ b/db_service/ScenarioEditor.cpp
@@ -5,6 +5,7 @@
 #include "../signs/SignShip.h"
 #include "services/DataStorageServiceFactory.h"
 #include "../core/EnvConfig.h"
+#include "../ui/DObjectProperties.h"
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QFileDialog>
@@ -98,9 +99,7 @@ void ScenarioEditor::setupUi()
 
 
     // Подключаемся к моменту завершения редактирования
-    connect(ui->treeWidget, &QTreeWidget::itemDoubleClicked, this, [this](QTreeWidgetItem *item, int column) {
-        m_treeItemEditMode = column == 1;
-    });
+    connect(ui->treeWidget, &QTreeWidget::itemDoubleClicked, this, &ScenarioEditor::itemDoubleClicked);
 
     ui->treeWidget->setEditTriggers(QTreeWidget::DoubleClicked | QTreeWidget::EditKeyPressed);
     connect(ui->treeWidget, &QTreeWidget::itemChanged, this, [=](QTreeWidgetItem *item,int column){
@@ -117,6 +116,27 @@ void ScenarioEditor::setupUi()
         }
     });
 
+}
+
+void ScenarioEditor::itemDoubleClicked(QTreeWidgetItem *item, int column)
+{
+    auto objectModel = item->data(0, Qt::UserRole).value<ObjectScenarioModel*>();
+    if (objectModel) {
+        showPropertiesDialog(objectModel->getTitle(), objectModel->properties());
+        return;
+    }
+    auto featureModel = item->data(0, Qt::UserRole).value<FeatureModel*>();
+    if (featureModel) {
+        showPropertiesDialog(featureModel->getTitle(), featureModel->properties());
+        return;
+    }
+    m_treeItemEditMode = column == 1;
+}
+
+void ScenarioEditor::showPropertiesDialog(const QString &title, const QMap<QString, PropertyModel *> &props)
+{
+    DObjectProperties dlg(title, props, this);
+    dlg.exec();
 }
 
 void ScenarioEditor::saveScenario(bool saveAs){

--- a/db_service/ScenarioEditor.h
+++ b/db_service/ScenarioEditor.h
@@ -6,6 +6,7 @@
 #include <QTreeWidget>
 #include <QJsonDocument>
 #include <QPushButton>
+#include <QMap>
 
 #include "ui_ScenarioEditor.h"
 
@@ -18,6 +19,8 @@
 #include "modules/daddscenariointeraction.h"
 #include "../map_widget/SimulationEventWidgetInMap.h"
 #include "../map_widget/MapWidget.h"
+
+class PropertyModel;
 
 namespace Ui {
     class ScenarioEditor;
@@ -95,6 +98,9 @@ private:
     QStringList findGeoProperties(const QJsonObject&);
 
     void handlePropertyEdit(QTreeWidgetItem *item, int column);
+
+    void itemDoubleClicked(QTreeWidgetItem *item, int column);
+    void showPropertiesDialog(const QString &title, const QMap<QString, PropertyModel*> &props);
 
     void createSignsFromObjects(QList<ObjectScenarioModel*> objects, QList<FeatureModel*> features);
     void createSignFromObject(ObjectScenarioModel* object);

--- a/models/FeatureModel.h
+++ b/models/FeatureModel.h
@@ -115,6 +115,7 @@ public:
     void setFontSize(const float &font_size) { m_font_size = font_size; }
     void setPosition(const int &position);
     void setProperties(const QMap<QString, PropertyModel*> props) { qDeleteAll(m_properties); m_properties.clear(); m_properties = props; }
+    const QMap<QString, PropertyModel*> &properties() const { return m_properties; }
     void setProperty(QString name, QVariant val);
 
 

--- a/ui/DObjectProperties.cpp
+++ b/ui/DObjectProperties.cpp
@@ -1,0 +1,109 @@
+#include "DObjectProperties.h"
+#include "ui_DObjectProperties.h"
+
+#include <QTableWidget>
+#include <QDialogButtonBox>
+#include <QLineEdit>
+#include <QSpinBox>
+#include <QDoubleSpinBox>
+#include <QCheckBox>
+#include <QHeaderView>
+#include <limits>
+
+#include "../models/PropertyModel.h"
+
+DObjectProperties::DObjectProperties(const QString &title,
+                                     const QMap<QString, PropertyModel*> &properties,
+                                     QWidget *parent)
+    : QDialog(parent),
+      ui(new Ui::DObjectProperties),
+      m_properties(properties)
+{
+    ui->setupUi(this);
+    setWindowTitle(title);
+    resize(600, 800);
+
+    buildTable();
+}
+
+DObjectProperties::~DObjectProperties()
+{
+    delete ui;
+}
+
+void DObjectProperties::buildTable()
+{
+    ui->tableWidget->setColumnCount(3);
+    QStringList headers{"Title", "Parameter", "Value"};
+    ui->tableWidget->setHorizontalHeaderLabels(headers);
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Interactive);
+    ui->tableWidget->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Interactive);
+    ui->tableWidget->setColumnWidth(1, 100);
+    ui->tableWidget->setColumnWidth(2, 100);
+
+    int row = 0;
+    for (auto prop : m_properties) {
+        ui->tableWidget->insertRow(row);
+        auto titleItem = new QTableWidgetItem(prop->title().isEmpty() ? prop->name() : prop->title());
+        titleItem->setFlags(titleItem->flags() & ~Qt::ItemIsEditable);
+        ui->tableWidget->setItem(row, 0, titleItem);
+
+        auto nameItem = new QTableWidgetItem(prop->name());
+        nameItem->setFlags(nameItem->flags() & ~Qt::ItemIsEditable);
+        ui->tableWidget->setItem(row, 1, nameItem);
+
+        QWidget *editor = nullptr;
+        QString type = prop->type();
+        if (type == PropertyModel::ValueType::BOOL) {
+            QCheckBox *cb = new QCheckBox(ui->tableWidget);
+            cb->setChecked(prop->value().toBool());
+            editor = cb;
+        } else if (type == PropertyModel::ValueType::INT) {
+            QSpinBox *sb = new QSpinBox(ui->tableWidget);
+            sb->setRange(std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+            sb->setValue(prop->value().toInt());
+            editor = sb;
+        } else if (type == PropertyModel::ValueType::FLOAT || type == PropertyModel::ValueType::DOUBLE) {
+            QDoubleSpinBox *dsb = new QDoubleSpinBox(ui->tableWidget);
+            dsb->setRange(-1e9, 1e9);
+            dsb->setDecimals(6);
+            dsb->setValue(prop->value().toDouble());
+            editor = dsb;
+        } else {
+            QLineEdit *le = new QLineEdit(prop->stringValue(), ui->tableWidget);
+            editor = le;
+        }
+        ui->tableWidget->setCellWidget(row, 2, editor);
+        m_editors.insert(prop, editor);
+        row++;
+    }
+
+    ui->tableWidget->setColumnHidden(1, true);
+}
+
+void DObjectProperties::accept()
+{
+    for (auto it = m_editors.constBegin(); it != m_editors.constEnd(); ++it) {
+        PropertyModel *prop = it.key();
+        QWidget *editor = it.value();
+        if (auto cb = qobject_cast<QCheckBox*>(editor)) {
+            prop->setValue(cb->isChecked());
+        } else if (auto sb = qobject_cast<QSpinBox*>(editor)) {
+            prop->setValue(sb->value());
+        } else if (auto dsb = qobject_cast<QDoubleSpinBox*>(editor)) {
+            prop->setValue(dsb->value());
+        } else if (auto le = qobject_cast<QLineEdit*>(editor)) {
+            prop->setValue(le->text());
+        }
+    }
+    QDialog::accept();
+}
+
+void DObjectProperties::on_btnToggleParam_clicked()
+{
+    bool hidden = ui->tableWidget->isColumnHidden(1);
+    ui->tableWidget->setColumnHidden(1, !hidden);
+    ui->btnToggleParam->setText(hidden ? tr("Скрыть параметр") : tr("Показать параметр"));
+}
+

--- a/ui/DObjectProperties.h
+++ b/ui/DObjectProperties.h
@@ -1,0 +1,35 @@
+#ifndef DOBJECTPROPERTIES_H
+#define DOBJECTPROPERTIES_H
+
+#include <QDialog>
+#include <QMap>
+
+class PropertyModel;
+
+namespace Ui {
+class DObjectProperties;
+}
+
+class DObjectProperties : public QDialog
+{
+    Q_OBJECT
+public:
+    explicit DObjectProperties(const QString &title,
+                               const QMap<QString, PropertyModel*> &properties,
+                               QWidget *parent = nullptr);
+    ~DObjectProperties();
+
+    void accept() override;
+
+private slots:
+    void on_btnToggleParam_clicked();
+
+private:
+    Ui::DObjectProperties *ui;
+    QMap<QString, PropertyModel*> m_properties;
+    QMap<PropertyModel*, QWidget*> m_editors;
+
+    void buildTable();
+};
+
+#endif // DOBJECTPROPERTIES_H

--- a/ui/DObjectProperties.ui
+++ b/ui/DObjectProperties.ui
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DObjectProperties</class>
+ <widget class="QDialog" name="DObjectProperties">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>800</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Properties</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="tableWidget">
+     <column>
+      <property name="text">
+       <string>Title</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Parameter</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Value</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="btnToggleParam">
+     <property name="text">
+      <string>Показать параметр</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>DObjectProperties</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DObjectProperties</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
## Summary
- show title, parameter and value fields in DObjectProperties table with optional parameter column
- allow toggling parameter visibility and set default dialog size to 600x800

## Testing
- `cmake ..` *(fails: Could not find Qt5)*
- `ctest --test-dir build` *(fails: No tests were found)*


------
https://chatgpt.com/codex/tasks/task_e_68b3622dd2b8832e85158a92cd580c65