### PR TITLE
Add SignAnimator for smooth sign updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(ScenarioClient
     signs/GeoUtil.cpp
     signs/SignBase.cpp
     signs/SignController.cpp
+    signs/SignAnimator.cpp
     signs/SignShip.cpp
     WebsocketService.cpp
     db_service/modelobjectsform.h
@@ -54,6 +55,7 @@ add_executable(ScenarioClient
     signs/GeoUtil.h
     signs/SignBase.h
     signs/SignController.h
+    signs/SignAnimator.h
     signs/sign_enums.h
     signs/SignShip.h
     WebsocketService.h

--- a/ScenarioClient.pro
+++ b/ScenarioClient.pro
@@ -36,6 +36,7 @@ SOURCES += \
     signs/geoutil.cpp \
     signs/sign_base.cpp \
     signs/sign_controller.cpp \
+    signs/SignAnimator.cpp \
     signs/sign_ship.cpp \
     websocketservice.cpp
 
@@ -55,6 +56,7 @@ HEADERS += \
     signs/geoutil.h \
     signs/sign_base.h \
     signs/sign_controller.h \
+    signs/SignAnimator.h \
     signs/sign_enums.h \
     signs/sign_ship.h \
     websocketservice.h

--- a/db_service/ScenarioEditor.cpp
+++ b/db_service/ScenarioEditor.cpp
@@ -3,6 +3,7 @@
 #include "../signs/SignFactory.h"
 #include "../delegates/PropertyItemDelegate.h"
 #include "../signs/SignShip.h"
+#include "../signs/SignAnimator.h"
 #include "services/DataStorageServiceFactory.h"
 #include "../core/EnvConfig.h"
 #include "../ui/DObjectProperties.h"
@@ -806,10 +807,13 @@ void ScenarioEditor::updateObjectStateFromModel(QJsonArray jsonObjectList, QJson
                 m_signController->updateSignOnMap(childSign);
             }
 
-            if (lon !=0 && lat !=0) {
-                sign->setCoordinatesInDegrees({QPointF(lat,lon)}, course);
-                m_signController->updateSignOnMap(sign);
-                // m_signController->updateSignOnMap(sign->getGisID(), lat, lon, course);
+            if (lon != 0 && lat != 0) {
+                auto current = sign->getCoordinatesInDegrees();
+                QPointF from;
+                if (!current.isEmpty())
+                    from = current.first();
+                SignAnimator::startAnimation(sign, from, QPointF(lat, lon),
+                                            course, 1000);
             }
             // смотрим появлись ли поля для отображения гео объектов
 

--- a/signs/SignAnimator.cpp
+++ b/signs/SignAnimator.cpp
@@ -1,0 +1,50 @@
+#include "SignAnimator.h"
+#include "SignBase.h"
+#include "SignController.h"
+
+QHash<QString, QTimer *> SignAnimator::m_timers;
+
+void SignAnimator::startAnimation(SignBase *sign, const QPointF &from,
+                                  const QPointF &to, double course,
+                                  int durationMs)
+{
+    if (!sign)
+        return;
+
+    // If coordinates are missing, perform immediate update
+    if ((from.isNull() || (from.x() == 0 && from.y() == 0)) ||
+        (to.isNull() || (to.x() == 0 && to.y() == 0))) {
+        sign->setCoordinatesInDegrees({to}, course);
+        SignController::getInstance()->updateSignOnMap(sign);
+        return;
+    }
+
+    QString key = sign->getUuid().toString();
+    if (m_timers.contains(key)) {
+        QTimer *old = m_timers.take(key);
+        old->stop();
+        old->deleteLater();
+    }
+
+    const int interval = 50;
+    QTimer *timer = new QTimer();
+    timer->setInterval(interval);
+    int elapsed = 0;
+
+    QObject::connect(timer, &QTimer::timeout, [=]() mutable {
+        elapsed += interval;
+        double t = qMin(1.0, static_cast<double>(elapsed) / durationMs);
+        double lat = from.x() + (to.x() - from.x()) * t;
+        double lon = from.y() + (to.y() - from.y()) * t;
+        sign->setCoordinatesInDegrees({QPointF(lat, lon)}, course);
+        SignController::getInstance()->updateSignOnMap(sign);
+        if (t >= 1.0) {
+            timer->stop();
+            timer->deleteLater();
+            m_timers.remove(key);
+        }
+    });
+
+    m_timers.insert(key, timer);
+    timer->start();
+}

--- a/signs/SignAnimator.h
+++ b/signs/SignAnimator.h
@@ -1,0 +1,26 @@
+#ifndef SIGNANIMATOR_H
+#define SIGNANIMATOR_H
+
+#include <QHash>
+#include <QObject>
+#include <QPointF>
+#include <QTimer>
+#include <QString>
+
+class SignBase;
+
+class SignAnimator : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SignAnimator(QObject *parent = nullptr) : QObject(parent) {}
+
+    static void startAnimation(SignBase *sign, const QPointF &from,
+                               const QPointF &to, double course,
+                               int durationMs);
+
+private:
+    static QHash<QString, QTimer *> m_timers;
+};
+
+#endif // SIGNANIMATOR_H


### PR DESCRIPTION
## Summary
- Add `SignAnimator` helper with timer-based interpolation and timer tracking
- Use `SignAnimator` in ScenarioEditor to animate sign position updates over server intervals
- Wire new files into build system

## Testing
- `./tests/run_tests.sh` *(fails: Could not find a package configuration file provided by "Qt5")*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b382664e14832e96f1b5733ad4c6bc