### PR TITLE
Add Russian comments and default gray grid background

### DIFF
--- a/diagramscene/DiagramSceneDlg.cpp
+++ b/diagramscene/DiagramSceneDlg.cpp
@@ -57,8 +57,7 @@
 #include <QtWidgets>
 
 const int InsertTextButton = 10;
-
-//! [0]
+// Конструктор диалогового окна сцены
 DiagramSceneDlg::DiagramSceneDlg()
 {
     createActions();
@@ -67,11 +66,12 @@ DiagramSceneDlg::DiagramSceneDlg()
 
     scene = new DiagramScene(itemMenu, this);
     scene->setSceneRect(QRectF(0, 0, 5000, 5000));
+    scene->setBackgroundBrush(QPixmap(":/images_diag/background1.png"));
+    if (!backgroundButtonGroup->buttons().isEmpty())
+        backgroundButtonGroup->buttons().first()->setChecked(true);
 
     connect(scene, &DiagramScene::itemInserted,
             this, &DiagramSceneDlg::itemInserted);
-//    connect(scene,SIGNAL(itemInserted(AlgoritmItem::AlgoritmType)),this,SLOT(itemInserted(AlgoritmItem::AlgoritmType)));
-//    connect(scene,SIGNAL(itemInserted(DiagramItem::DiagramType)),this,SLOT(itemInserted(DiagramItem::DiagramType)));
     connect(scene, &DiagramScene::textInserted,
             this, &DiagramSceneDlg::textInserted);
     connect(scene, &DiagramScene::itemSelected,
@@ -89,13 +89,12 @@ DiagramSceneDlg::DiagramSceneDlg()
 
     setCentralWidget(widget);
     setWindowTitle(tr("Редактор поведенческого ядра объекта"));
-    setUnifiedTitleAndToolBarOnMac(true);// B-)
+    setUnifiedTitleAndToolBarOnMac(true);
     scene->setView(view);
     connect(scene,SIGNAL(zoom(int)),this,SLOT(changeZoom(int)));
 }
-//! [0]
 
-//! [1]
+// Обработчик выбора фона сцены
 void DiagramSceneDlg::backgroundButtonGroupClicked(QAbstractButton *button)
 {
     const QList<QAbstractButton *> buttons = backgroundButtonGroup->buttons();
@@ -117,6 +116,7 @@ void DiagramSceneDlg::backgroundButtonGroupClicked(QAbstractButton *button)
     view->update();
 }
 
+// Обработчик выбора типа алгоритма
 void DiagramSceneDlg::algoritmButtonGroupClicked(QAbstractButton *button)
 {
     const QList<QAbstractButton *> buttons = algoritmButtonGroup->buttons();
@@ -125,12 +125,11 @@ void DiagramSceneDlg::algoritmButtonGroupClicked(QAbstractButton *button)
             button->setChecked(false);
     }
         const int id = algoritmButtonGroup->id(button);
-    scene->setItemType(static_cast<AlgoritmItem::AlgoritmType>(id));//TODO
+    scene->setItemType(static_cast<AlgoritmItem::AlgoritmType>(id));
     scene->setMode(DiagramScene::InsertItem);
 }
-//! [1]
 
-//! [2]
+// Обработчик выбора элемента диаграммы
 void DiagramSceneDlg::buttonGroupClicked(QAbstractButton *button)
 {
     const QList<QAbstractButton *> buttons = buttonGroup->buttons();
@@ -146,9 +145,8 @@ void DiagramSceneDlg::buttonGroupClicked(QAbstractButton *button)
         scene->setMode(DiagramScene::InsertItem);
     }
 }
-//! [2]
 
-//! [3]
+// Удаляет выбранные элементы
 void DiagramSceneDlg::deleteItem()
 {
     QList<QGraphicsItem *> selectedItems = scene->selectedItems();
@@ -170,16 +168,14 @@ void DiagramSceneDlg::deleteItem()
          delete item;
      }
 }
-//! [3]
 
-//! [4]
+// Изменяет режим указателя на сцене
 void DiagramSceneDlg::pointerGroupClicked()
 {
     scene->setMode(DiagramScene::Mode(pointerTypeGroup->checkedId()));
 }
-//! [4]
 
-//! [5]
+// Перемещает выделенный элемент на передний план
 void DiagramSceneDlg::bringToFront()
 {
     if (scene->selectedItems().isEmpty())
@@ -195,9 +191,8 @@ void DiagramSceneDlg::bringToFront()
     }
     selectedItem->setZValue(zValue);
 }
-//! [5]
 
-//! [6]
+// Перемещает выделенный элемент на задний план
 void DiagramSceneDlg::sendToBack()
 {
     if (scene->selectedItems().isEmpty())
@@ -213,51 +208,39 @@ void DiagramSceneDlg::sendToBack()
     }
     selectedItem->setZValue(zValue);
 }
-//! [6]
 
-//! [7]
-//void DiagramSceneDlg::itemInserted(DiagramItem *item)
-//{
-//    pointerTypeGroup->button(int(DiagramScene::MoveItem))->setChecked(true);
-//    scene->setMode(DiagramScene::Mode(pointerTypeGroup->checkedId()));
-//    buttonGroup->button(int(item->diagramType()))->setChecked(false);
-//}
+// Обработчик добавления нового элемента алгоритма
 void DiagramSceneDlg::itemInserted(AlgoritmItem *item)
 {
     pointerTypeGroup->button(int(DiagramScene::MoveItem))->setChecked(true);
     scene->setMode(DiagramScene::Mode(pointerTypeGroup->checkedId()));
-//    buttonGroup->button(int(item->diagramType()))->setChecked(false);
     QAbstractButton *btn = algoritmButtonGroup->button(int(item->diagramType()));
 
     if (btn!=nullptr)
     btn->setChecked(false);
 
 }
-//! [7]
 
-//! [8]
+// Обработчик вставки текстового элемента
 void DiagramSceneDlg::textInserted(QGraphicsTextItem *)
 {
     buttonGroup->button(InsertTextButton)->setChecked(false);
     scene->setMode(DiagramScene::Mode(pointerTypeGroup->checkedId()));
 }
-//! [8]
 
-//! [9]
+// Обновляет текущий шрифт текста
 void DiagramSceneDlg::currentFontChanged(const QFont &)
 {
     handleFontChange();
 }
-//! [9]
 
-//! [10]
+// Изменяет размер выбранного шрифта
 void DiagramSceneDlg::fontSizeChanged(const QString &)
 {
     handleFontChange();
 }
-//! [10]
 
-//! [11]
+// Изменяет масштаб отображения сцены
 void DiagramSceneDlg::sceneScaleChanged(const QString &scale)
 {
     double newScale = scale.left(scale.indexOf(tr("%"))).toDouble() / 100.0;
@@ -266,9 +249,8 @@ void DiagramSceneDlg::sceneScaleChanged(const QString &scale)
     view->translate(oldMatrix.dx(), oldMatrix.dy());
     view->scale(newScale, newScale);
 }
-//! [11]
 
-//! [12]
+// Изменяет цвет текста
 void DiagramSceneDlg::textColorChanged()
 {
     textAction = qobject_cast<QAction *>(sender());
@@ -277,9 +259,8 @@ void DiagramSceneDlg::textColorChanged()
                                      qvariant_cast<QColor>(textAction->data())));
     textButtonTriggered();
 }
-//! [12]
 
-//! [13]
+// Изменяет цвет выбранного элемента
 void DiagramSceneDlg::itemColorChanged()
 {
     fillAction = qobject_cast<QAction *>(sender());
@@ -288,9 +269,8 @@ void DiagramSceneDlg::itemColorChanged()
                                      qvariant_cast<QColor>(fillAction->data())));
     fillButtonTriggered();
 }
-//! [13]
 
-//! [14]
+// Изменяет цвет линий соединений
 void DiagramSceneDlg::lineColorChanged()
 {
     lineAction = qobject_cast<QAction *>(sender());
@@ -299,30 +279,26 @@ void DiagramSceneDlg::lineColorChanged()
                                      qvariant_cast<QColor>(lineAction->data())));
     lineButtonTriggered();
 }
-//! [14]
 
-//! [15]
+// Активирует режим ввода текста
 void DiagramSceneDlg::textButtonTriggered()
 {
     scene->setTextColor(qvariant_cast<QColor>(textAction->data()));
 }
-//! [15]
 
-//! [16]
+// Активирует выбор цвета заполнения
 void DiagramSceneDlg::fillButtonTriggered()
 {
     scene->setItemColor(qvariant_cast<QColor>(fillAction->data()));
 }
-//! [16]
 
-//! [17]
+// Активирует выбор цвета линий
 void DiagramSceneDlg::lineButtonTriggered()
 {
     scene->setLineColor(qvariant_cast<QColor>(lineAction->data()));
 }
-//! [17]
 
-//! [18]
+// Обрабатывает изменение параметров шрифта
 void DiagramSceneDlg::handleFontChange()
 {
     QFont font = fontCombo->currentFont();
@@ -333,9 +309,8 @@ void DiagramSceneDlg::handleFontChange()
 
     scene->setFont(font);
 }
-//! [18]
 
-//! [19]
+// Реагирует на выбор элемента сцены
 void DiagramSceneDlg::itemSelected(QGraphicsItem *item)
 {
     DiagramTextItem *textItem =
@@ -349,6 +324,7 @@ void DiagramSceneDlg::itemSelected(QGraphicsItem *item)
     underlineAction->setChecked(font.underline());
 }
 
+// Меняет масштаб сцены через колесо мыши
 void DiagramSceneDlg::changeZoom(int i)
 {
     int curIndex = sceneScaleCombo->currentIndex()+i;
@@ -358,9 +334,8 @@ void DiagramSceneDlg::changeZoom(int i)
         curIndex = 4;
     sceneScaleCombo->setCurrentIndex(curIndex);
 }
-//! [19]
 
-//! [20]
+// Показывает информацию о приложении
 void DiagramSceneDlg::about()
 {
     QMessageBox::about(this, tr("О программе"),
@@ -370,9 +345,8 @@ void DiagramSceneDlg::about()
                           " Предоставляет графический интерфейс для создания алгоритмов, "
                           "и показывающий поток данных между ними."));
 }
-//! [20]
 
-//! [21]
+// Создаёт набор инструментов
 void DiagramSceneDlg::createToolBox()
 {
     buttonGroup = new QButtonGroup(this);
@@ -384,7 +358,6 @@ void DiagramSceneDlg::createToolBox()
     layout->addWidget(createCellWidget(tr("Process"), DiagramItem::Step),0, 1);
     layout->addWidget(createCellWidget(tr("Input/Output"), DiagramItem::Io), 1, 0);
     layout->addWidget(createCellWidget(tr("Start/End"), DiagramItem::StartEnd), 2, 0);
-//! [21]
 
     QToolButton *textButton = new QToolButton;
     textButton->setCheckable(true);
@@ -424,7 +397,6 @@ void DiagramSceneDlg::createToolBox()
     QWidget *backgroundWidget = new QWidget;
     backgroundWidget->setLayout(backgroundLayout);
 
-    //
     algoritmButtonGroup = new QButtonGroup(this);
     connect(algoritmButtonGroup, QOverload<QAbstractButton *>::of(&QButtonGroup::buttonClicked),
             this, &DiagramSceneDlg::algoritmButtonGroupClicked);
@@ -434,8 +406,6 @@ void DiagramSceneDlg::createToolBox()
     algoritmLayout->addWidget(createAlgoritmCellWidget(tr("Условие"),AlgoritmItem::AlgoritmType::CONDITION), 0, 1);
     algoritmLayout->addWidget(createAlgoritmCellWidget(tr("Событие"),AlgoritmItem::AlgoritmType::EVENT), 1, 0);
      algoritmLayout->addWidget(createAlgoritmCellWidget(tr("Параметр"),AlgoritmItem::AlgoritmType::PARAM), 1, 1);
-//    algoritmLayout->addWidget(createAlgoritmCellWidget(tr("alg_1_4"),
-//                                                           ":/images_diag/background4.png"), 1, 1);
 
     algoritmLayout->setRowStretch(2, 10);
     algoritmLayout->setColumnStretch(2, 10);
@@ -443,7 +413,6 @@ void DiagramSceneDlg::createToolBox()
     QWidget *algoritmWidget = new QWidget;
     algoritmWidget->setLayout(algoritmLayout);
 
-//! [22]
     toolBox = new QToolBox;
     toolBox->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Ignored));
     toolBox->setMinimumWidth(itemWidget->sizeHint().width());
@@ -451,9 +420,8 @@ void DiagramSceneDlg::createToolBox()
     toolBox->addItem(algoritmWidget, tr("Формы алгоритмов"));
     toolBox->addItem(backgroundWidget, tr("Базовый фон"));
 }
-//! [22]
 
-//! [23]
+// Создаёт действия интерфейса
 void DiagramSceneDlg::createActions()
 {
     toFrontAction = new QAction(QIcon(":/images_diag/bringtofront.png"),
@@ -461,7 +429,6 @@ void DiagramSceneDlg::createActions()
     toFrontAction->setShortcut(tr("Ctrl+F"));
     toFrontAction->setStatusTip(tr("Вывести элемент на передний план"));
     connect(toFrontAction, &QAction::triggered, this, &DiagramSceneDlg::bringToFront);
-//! [23]
 
     sendBackAction = new QAction(QIcon(":/images_diag/sendtoback.png"), tr("На &задний план"), this);
     sendBackAction->setShortcut(tr("Ctrl+T"));
@@ -485,12 +452,10 @@ void DiagramSceneDlg::createActions()
 
     saveAction = new QAction(tr("&Сохранить"), this);
     saveAction->setShortcuts(QKeySequence::Save);
-//    exitAction->setStatusTip(tr("Закрыть программу"));
     connect(saveAction, &QAction::triggered, this, &QWidget::close);
 
     saveAsAction = new QAction(tr("&Сохранить как"), this);
     saveAsAction->setShortcuts(QKeySequence::SaveAs);
-//    exitAction->setStatusTip(tr("Закрыть программу"));
     connect(saveAsAction, &QAction::triggered, this, &QWidget::close);
 
     exitAction = new QAction(tr("&Выход"), this);
@@ -520,7 +485,7 @@ void DiagramSceneDlg::createActions()
     connect(aboutAction, &QAction::triggered, this, &DiagramSceneDlg::about);
 }
 
-//! [24]
+// Создаёт меню приложения
 void DiagramSceneDlg::createMenus()
 {
     fileMenu = menuBar()->addMenu(tr("&Файл"));
@@ -539,12 +504,10 @@ void DiagramSceneDlg::createMenus()
     aboutMenu = menuBar()->addMenu(tr("&Помощь"));
     aboutMenu->addAction(aboutAction);
 }
-//! [24]
 
-//! [25]
+// Создаёт панели инструментов
 void DiagramSceneDlg::createToolbars()
 {
-//! [25]
     editToolBar = addToolBar(tr("Редактировать"));
     editToolBar->addAction(deleteAction);
     editToolBar->addAction(toFrontAction);
@@ -572,7 +535,6 @@ void DiagramSceneDlg::createToolbars()
     connect(fontColorToolButton, &QAbstractButton::clicked,
             this, &DiagramSceneDlg::textButtonTriggered);
 
-//! [26]
     fillColorToolButton = new QToolButton;
     fillColorToolButton->setPopupMode(QToolButton::MenuButtonPopup);
     fillColorToolButton->setMenu(createColorMenu(SLOT(itemColorChanged()), Qt::white));
@@ -581,7 +543,6 @@ void DiagramSceneDlg::createToolbars()
                                      ":/images_diag/floodfill.png", Qt::white));
     connect(fillColorToolButton, &QAbstractButton::clicked,
             this, &DiagramSceneDlg::fillButtonTriggered);
-//! [26]
 
     lineColorToolButton = new QToolButton;
     lineColorToolButton->setPopupMode(QToolButton::MenuButtonPopup);
@@ -630,11 +591,9 @@ void DiagramSceneDlg::createToolbars()
     pointerToolbar->addWidget(pointerButton);
     pointerToolbar->addWidget(linePointerButton);
     pointerToolbar->addWidget(sceneScaleCombo);
-//! [27]
 }
-//! [27]
 
-//! [28]
+// Создаёт элемент выбора фонового изображения
 QWidget *DiagramSceneDlg::createBackgroundCellWidget(const QString &text, const QString &image)
 {
     QToolButton *button = new QToolButton;
@@ -654,7 +613,8 @@ QWidget *DiagramSceneDlg::createBackgroundCellWidget(const QString &text, const 
     return widget;
 }
 
-QWidget *DiagramSceneDlg::createAlgoritmCellWidget(const QString &text, AlgoritmItem::AlgoritmType type)//TODO
+// Создаёт элемент выбора типа алгоритма
+QWidget *DiagramSceneDlg::createAlgoritmCellWidget(const QString &text, AlgoritmItem::AlgoritmType type)
 {
     AlgoritmItem item(type, itemMenu);
     QIcon icon(item.image(type));
@@ -674,9 +634,8 @@ QWidget *DiagramSceneDlg::createAlgoritmCellWidget(const QString &text, Algoritm
 
     return widget;
 }
-//! [28]
 
-//! [29]
+// Создаёт элемент выбора стандартной блок-схемы
 QWidget *DiagramSceneDlg::createCellWidget(const QString &text, DiagramItem::DiagramType type)
 {
 
@@ -698,9 +657,8 @@ QWidget *DiagramSceneDlg::createCellWidget(const QString &text, DiagramItem::Dia
 
     return widget;
 }
-//! [29]
 
-//! [30]
+// Создаёт меню выбора цвета
 QMenu *DiagramSceneDlg::createColorMenu(const char *slot, QColor defaultColor)
 {
     QList<QColor> colors;
@@ -721,9 +679,8 @@ QMenu *DiagramSceneDlg::createColorMenu(const char *slot, QColor defaultColor)
     }
     return colorMenu;
 }
-//! [30]
 
-//! [31]
+// Создаёт иконку для кнопки выбора цвета
 QIcon DiagramSceneDlg::createColorToolButtonIcon(const QString &imageFile, QColor color)
 {
     QPixmap pixmap(50, 80);
@@ -738,9 +695,8 @@ QIcon DiagramSceneDlg::createColorToolButtonIcon(const QString &imageFile, QColo
 
     return QIcon(pixmap);
 }
-//! [31]
 
-//! [32]
+// Создаёт одноцветную иконку
 QIcon DiagramSceneDlg::createColorIcon(QColor color)
 {
     QPixmap pixmap(20, 20);
@@ -750,4 +706,3 @@ QIcon DiagramSceneDlg::createColorIcon(QColor color)
 
     return QIcon(pixmap);
 }
-//! [32]

--- a/diagramscene/DiagramSceneDlg.h
+++ b/diagramscene/DiagramSceneDlg.h
@@ -73,7 +73,6 @@ class QAbstractButton;
 class QGraphicsView;
 QT_END_NAMESPACE
 
-//! [0]
 class DiagramSceneDlg : public QMainWindow
 {
     Q_OBJECT
@@ -89,7 +88,6 @@ private slots:
     void pointerGroupClicked();
     void bringToFront();
     void sendToBack();
-//    void itemInserted(DiagramItem *item);
     void textInserted(QGraphicsTextItem *item);
     void currentFontChanged(const QFont &font);
     void fontSizeChanged(const QString &size);
@@ -166,6 +164,5 @@ private:
     QAction *fillAction;
     QAction *lineAction;
 };
-//! [0]
 
 #endif // DIAGRAMSCENEDLG_H

--- a/diagramscene/diagramscene.cpp
+++ b/diagramscene/diagramscene.cpp
@@ -53,24 +53,26 @@
 
 #include <QGraphicsSceneMouseEvent>
 #include <QTextCursor>
+#include <QPixmap>
 
-//! [0]
+// Конструктор сцены диаграммы
 DiagramScene::DiagramScene(QMenu *itemMenu, QObject *parent)
     : QGraphicsScene(parent)
 {
     myItemMenu = itemMenu;
     myMode = MoveItem;
-    myItemType = AlgoritmItem::ALGORITM;//DiagramItem::Step;
+    myItemType = AlgoritmItem::ALGORITM;
     line = nullptr;
     textItem = nullptr;
     myItemColor = Qt::white;
     myTextColor = Qt::black;
     myLineColor = Qt::black;
-            center = sceneRect().center();
+    center = sceneRect().center();
+    // Устанавливаем фон "Серая сетка" по умолчанию
+    setBackgroundBrush(QPixmap(":/images_diag/background1.png"));
 }
-//! [0]
 
-//! [1]
+// Устанавливает цвет стрелок
 void DiagramScene::setLineColor(const QColor &color)
 {
     myLineColor = color;
@@ -80,9 +82,8 @@ void DiagramScene::setLineColor(const QColor &color)
         update();
     }
 }
-//! [1]
 
-//! [2]
+// Устанавливает цвет текста
 void DiagramScene::setTextColor(const QColor &color)
 {
     myTextColor = color;
@@ -91,21 +92,18 @@ void DiagramScene::setTextColor(const QColor &color)
         item->setDefaultTextColor(myTextColor);
     }
 }
-//! [2]
 
-//! [3]
+// Устанавливает цвет элементов алгоритма
 void DiagramScene::setItemColor(const QColor &color)
 {
     myItemColor = color;
     if (isItemChange(DiagramItem::Type)) {
-//        DiagramItem *item = qgraphicsitem_cast<DiagramItem *>(selectedItems().first());
         AlgoritmItem *item = qgraphicsitem_cast<AlgoritmItem *>(selectedItems().first());
         item->setBrush(myItemColor);
     }
 }
-//! [3]
 
-//! [4]
+// Устанавливает шрифт текстовых элементов
 void DiagramScene::setFont(const QFont &font)
 {
     myFont = font;
@@ -118,23 +116,25 @@ void DiagramScene::setFont(const QFont &font)
     }
 }
 
+// Запоминает указатель на отображающий сцену виджет
 void DiagramScene::setView(QGraphicsView *view)
 {
     parentView = view;
 }
-//! [4]
 
+// Меняет режим работы сцены
 void DiagramScene::setMode(Mode mode)
 {
     myMode = mode;
 }
 
+// Устанавливает тип добавляемого алгоритмического элемента
 void DiagramScene::setItemType(AlgoritmItem::AlgoritmType type)
 {
     myItemType = type;
 }
 
-//! [5]
+// Завершает редактирование текста
 void DiagramScene::editorLostFocus(DiagramTextItem *item)
 {
     QTextCursor cursor = item->textCursor();
@@ -146,9 +146,8 @@ void DiagramScene::editorLostFocus(DiagramTextItem *item)
         item->deleteLater();
     }
 }
-//! [5]
 
-//! [6]
+// Обрабатывает нажатие кнопок мыши на сцене
 void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {
     if (center.x()==0 && center.y()==0)
@@ -166,7 +165,6 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
     AlgoritmItem *item;
     switch (myMode) {
         case InsertItem:{
-//            item = new DiagramItem(myItemType, myItemMenu);
             QString title = "";
             QList<QPair<QString,QString>> in;
             QList<QPair<QString,QString>> out;
@@ -203,14 +201,12 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
             item->setPos(mouseEvent->scenePos());
             emit itemInserted(item);}
             break;
-//! [6] //! [7]
         case InsertLine:
             line = new QGraphicsLineItem(QLineF(mouseEvent->scenePos(),
                                         mouseEvent->scenePos()));
             line->setPen(QPen(myLineColor, 2));
             addItem(line);
             break;
-//! [7] //! [8]
         case InsertText:
             textItem = new DiagramTextItem();
             textItem->setFont(myFont);
@@ -224,22 +220,19 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
             textItem->setDefaultTextColor(myTextColor);
             textItem->setPos(mouseEvent->scenePos());
             emit textInserted(textItem);
-//! [8] //! [9]
     default:
         ;
     }
     QGraphicsScene::mousePressEvent(mouseEvent);
 }
-//! [9]
 
-//! [10]
+// Обрабатывает перемещение мыши
 void DiagramScene::mouseMoveEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {
     if (myMode == MoveFullScene){
 
         newCenter = QPointF(center.x() + beginMousePos.x() - QCursor::pos().x(),
-                         center.y() + beginMousePos.y() - QCursor::pos().y());
-//        qDebug()<<"center"<<center<<" beginMousePos"<<beginMousePos<<" mouseEvent->pos()"<<QCursor::pos();
+                             center.y() + beginMousePos.y() - QCursor::pos().y());
         parentView->centerOn(newCenter);
 
     }
@@ -250,9 +243,8 @@ void DiagramScene::mouseMoveEvent(QGraphicsSceneMouseEvent *mouseEvent)
         QGraphicsScene::mouseMoveEvent(mouseEvent);
     }
 }
-//! [10]
 
-//! [11]
+// Обрабатывает отпускание кнопок мыши
 void DiagramScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {
     if (myMode == MoveFullScene){
@@ -279,7 +271,6 @@ void DiagramScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent)
             if (static_cast<QGraphicsEllipseItem *>(var)->data(Qt::UserRole).toString().contains("in"))
                 endItem = static_cast<QGraphicsEllipseItem *>(var);
         }
-//! [11] //! [12]
 
         if (startItem && startItem->parentItem()
                 && endItem && endItem->parentItem()) {
@@ -288,16 +279,15 @@ void DiagramScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent)
             arrow->setColor(myLineColor);
             static_cast<AlgoritmItem*>(startItem->parentItem())->addArrow(arrow);
             static_cast<AlgoritmItem*>(endItem->parentItem())->addArrow(arrow);
-//            arrow->setZValue(-1);
             addItem(arrow);
             arrow->updatePosition();
         }
     }
-//! [12] //! [13]
     line = nullptr;
     QGraphicsScene::mouseReleaseEvent(mouseEvent);
 }
 
+// Обрабатывает прокрутку колесом мыши
 void DiagramScene::wheelEvent(QGraphicsSceneWheelEvent *mouseEvent)
 {
     if (mouseEvent->delta()>0)
@@ -305,13 +295,11 @@ void DiagramScene::wheelEvent(QGraphicsSceneWheelEvent *mouseEvent)
     else
         emit zoom(-1);
 }
-//! [13]
 
-//! [14]
+// Проверяет, изменился ли элемент указанного типа
 bool DiagramScene::isItemChange(int type) const
 {
     const QList<QGraphicsItem *> items = selectedItems();
     const auto cb = [type](const QGraphicsItem *item) { return item->type() == type; };
     return std::find_if(items.begin(), items.end(), cb) != items.end();
 }
-//! [14]

--- a/diagramscene/diagramscene.h
+++ b/diagramscene/diagramscene.h
@@ -68,7 +68,6 @@ class QGraphicsTextItem;
 class QColor;
 QT_END_NAMESPACE
 
-//! [0]
 class DiagramScene : public QGraphicsScene
 {
     Q_OBJECT
@@ -76,37 +75,68 @@ class DiagramScene : public QGraphicsScene
 public:
     enum Mode { InsertItem, InsertLine, InsertText, MoveItem, MoveFullScene };
 
+    // Конструктор сцены диаграммы
     explicit DiagramScene(QMenu *itemMenu, QObject *parent = nullptr);
+
+    // Возвращает текущий шрифт текста
     QFont font() const { return myFont; }
+
+    // Возвращает цвет текста
     QColor textColor() const { return myTextColor; }
+
+    // Возвращает цвет элементов
     QColor itemColor() const { return myItemColor; }
+
+    // Возвращает цвет линий
     QColor lineColor() const { return myLineColor; }
+
+    // Устанавливает цвет линий
     void setLineColor(const QColor &color);
+
+    // Устанавливает цвет текста
     void setTextColor(const QColor &color);
+
+    // Устанавливает цвет элементов
     void setItemColor(const QColor &color);
+
+    // Устанавливает шрифт текста
     void setFont(const QFont &font);
+
+    // Запоминает указатель на отображающий сцену виджет
     void setView(QGraphicsView *view);
 
 public slots:
+    // Меняет текущий режим работы сцены
     void setMode(Mode mode);
-//    void setItemType(DiagramItem::DiagramType type);
+
+    // Устанавливает тип добавляемого алгоритмического элемента
     void setItemType(AlgoritmItem::AlgoritmType type);
+
+    // Обрабатывает потерю фокуса текстовым редактором
     void editorLostFocus(DiagramTextItem *item);
 
 signals:
-//    void itemInserted(DiagramItem *item);
+    // Сигнал о вставке нового элемента
     void itemInserted(AlgoritmItem *item);
     void textInserted(QGraphicsTextItem *item);
     void itemSelected(QGraphicsItem *item);
     void zoom(int i);
 
 protected:
+    // Обработка нажатия кнопок мыши на сцене
     void mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent) override;
+
+    // Обработка перемещения мыши
     void mouseMoveEvent(QGraphicsSceneMouseEvent *mouseEvent) override;
+
+    // Обработка отпускания кнопок мыши
     void mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent) override;
+
+    // Обработка прокрутки колесом мыши
     void wheelEvent(QGraphicsSceneWheelEvent *mouseEvent) override;
 
 private:
+    // Проверяет, изменился ли элемент указанного типа
     bool isItemChange(int type) const;
 
     QGraphicsView *parentView = new QGraphicsView();
@@ -114,7 +144,6 @@ private:
     QPointF center;
     QPointF newCenter;
 
-//    DiagramItem::DiagramType
     AlgoritmItem::AlgoritmType myItemType;
     QMenu *myItemMenu;
     Mode prevMode;
@@ -128,6 +157,5 @@ private:
     QColor myItemColor;
     QColor myLineColor;
 };
-//! [0]
 
 #endif // DIAGRAMSCENE_H


### PR DESCRIPTION
## Summary
- Add detailed Russian comments to DiagramScene and its dialog functions
- Set gray grid as the default scene background and remove dead code

## Testing
- `./tests/run_tests.sh` *(fails: Could not find a package configuration file provided by "Qt5")*

------
https://chatgpt.com/codex/tasks/task_e_68b44841a8a4832eab5d37b1bbf3d2b0