### PR TITLE
Refactor diagramscene algorithm item and fix arrow usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,7 @@ add_executable(ScenarioClient
         db_service/modules/dscenariodistrict.ui
 
         diagramscene/DiagramSceneDlg.h
-        diagramscene/algoritmitem.h
+        diagramscene/algorithmitem.h
         diagramscene/diagramitem.h
         diagramscene/diagramscene.h
         diagramscene/arrow.h
@@ -167,7 +167,7 @@ add_executable(ScenarioClient
         diagramscene/itemtoolbox.h
 
         diagramscene/DiagramSceneDlg.cpp
-        diagramscene/algoritmitem.cpp
+        diagramscene/algorithmitem.cpp
         diagramscene/diagramitem.cpp
         diagramscene/itemtoolbox.cpp
         diagramscene/arrow.cpp

--- a/diagramscene/DiagramSceneDlg.cpp
+++ b/diagramscene/DiagramSceneDlg.cpp
@@ -8,7 +8,6 @@
 
 #include <QtWidgets>
 #include <algorithm>
-#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QJsonDocument>
@@ -72,7 +71,7 @@ protected:
             }
         }
 
-        auto *temp = new AlgoritmItem(AlgoritmItem::ALGORITM, nullptr, title, inParams, outParams);
+        auto *temp = new AlgorithmItem(AlgorithmItem::ALGORITM, nullptr, title, inParams, outParams);
         temp->setBrush(QColor("#E3E3FD"));
         QGraphicsScene tmpScene;
         tmpScene.addItem(temp);
@@ -159,7 +158,7 @@ void DiagramSceneDlg::buttonGroupClicked(QAbstractButton *button)
     if (id == InsertTextButton) {
         scene->setMode(DiagramScene::InsertText);
     } else {
-        scene->setItemType(AlgoritmItem::AlgoritmType(id));
+        scene->setItemType(AlgorithmItem::AlgorithmType(id));
         scene->setMode(DiagramScene::InsertItem);
     }
 }
@@ -172,16 +171,16 @@ void DiagramSceneDlg::deleteItem()
         if (item->type() == Arrow::Type) {
             scene->removeItem(item);
             Arrow *arrow = qgraphicsitem_cast<Arrow *>(item);
-            qgraphicsitem_cast<AlgoritmItem *>(arrow->_startItem()->parentItem())->removeArrow(arrow);
-            qgraphicsitem_cast<AlgoritmItem *>(arrow->_endItem()->parentItem())->removeArrow(arrow);
+            qgraphicsitem_cast<AlgorithmItem *>(arrow->startItem()->parentItem())->removeArrow(arrow);
+            qgraphicsitem_cast<AlgorithmItem *>(arrow->endItem()->parentItem())->removeArrow(arrow);
             delete item;
         }
     }
 
     selectedItems = scene->selectedItems();
     for (QGraphicsItem *item : qAsConst(selectedItems)) {
-         if (item->type() == AlgoritmItem::Type)
-             qgraphicsitem_cast<AlgoritmItem *>(item)->removeArrows();
+         if (item->type() == AlgorithmItem::Type)
+             qgraphicsitem_cast<AlgorithmItem *>(item)->removeArrows();
          scene->removeItem(item);
          delete item;
      }
@@ -246,12 +245,13 @@ void DiagramSceneDlg::sendToBack()
 }
 
 // Обработчик добавления нового элемента алгоритма
-void DiagramSceneDlg::itemInserted(AlgoritmItem *item)
+void DiagramSceneDlg::itemInserted(AlgorithmItem *item)
 {
     pointerTypeGroup->button(int(DiagramScene::MoveItem))->setChecked(true);
     scene->setMode(DiagramScene::Mode(pointerTypeGroup->checkedId()));
 }
 
+// Открывает диалог выбора объекта и добавляет его на сцену
 void DiagramSceneDlg::openObjectSelectDialog()
 {
     ObjectSelectDialog dlg(this);
@@ -275,6 +275,7 @@ void DiagramSceneDlg::openObjectSelectDialog()
     }
 }
 
+// Настраивает фон сцены
 void DiagramSceneDlg::openBackgroundSettings()
 {
     QDialog dlg(this);

--- a/diagramscene/DiagramSceneDlg.h
+++ b/diagramscene/DiagramSceneDlg.h
@@ -2,7 +2,7 @@
 #define DIAGRAMSCENEDLG_H
 
 #include "diagramitem.h"
-#include "algoritmitem.h"
+#include "algorithmitem.h"
 
 #include <QMainWindow>
 
@@ -28,35 +28,61 @@ class DiagramSceneDlg : public QMainWindow
     Q_OBJECT
 
 public:
+   // Создает диалоговое окно редактирования диаграммы
    DiagramSceneDlg();
 
 private slots:
+   // Обрабатывает выбор фона сцены
    void backgroundButtonGroupClicked(QAbstractButton *button);
-    void buttonGroupClicked(QAbstractButton *button);
-    void deleteItem();
-    void pointerGroupClicked();
-    void bringToFront();
-    void sendToBack();
-    void textInserted(QGraphicsTextItem *item);
-    void currentFontChanged(const QFont &font);
-    void fontSizeChanged(const QString &size);
-    void sceneScaleChanged(const QString &scale);
-    void textColorChanged();
-    void itemColorChanged();
-    void lineColorChanged();
-    void textButtonTriggered();
-    void fillButtonTriggered();
-    void lineButtonTriggered();
-    void handleFontChange();
-    void itemSelected(QGraphicsItem *item);
-    void changeZoom(int);
-    void about();
-    void singleLineButtonClicked();
-    void handleLineInserted();
+   // Обрабатывает выбор типа элемента
+   void buttonGroupClicked(QAbstractButton *button);
+   // Удаляет выделенный элемент
+   void deleteItem();
+   // Переключает режим указателя
+   void pointerGroupClicked();
+   // Поднимает элемент на передний план
+   void bringToFront();
+   // Отправляет элемент на задний план
+   void sendToBack();
+   // Обрабатывает вставку текстового элемента
+   void textInserted(QGraphicsTextItem *item);
+   // Изменяет текущий шрифт
+   void currentFontChanged(const QFont &font);
+   // Изменяет размер шрифта
+   void fontSizeChanged(const QString &size);
+   // Изменяет масштаб сцены
+   void sceneScaleChanged(const QString &scale);
+   // Меняет цвет текста
+   void textColorChanged();
+   // Меняет цвет элементов
+   void itemColorChanged();
+   // Меняет цвет линий
+   void lineColorChanged();
+   // Вставляет текстовый элемент
+   void textButtonTriggered();
+   // Заливка элемента
+   void fillButtonTriggered();
+   // Вставка линий
+   void lineButtonTriggered();
+   // Обработка смены шрифта
+   void handleFontChange();
+   // Обработка выбора элемента
+   void itemSelected(QGraphicsItem *item);
+   // Изменяет масштаб сцены
+   void changeZoom(int);
+   // Отображает информацию о программе
+   void about();
+   // Включает режим одиночной линии
+   void singleLineButtonClicked();
+   // Обработка вставки линии
+   void handleLineInserted();
 
-    void itemInserted(AlgoritmItem *item);
-    void openObjectSelectDialog();
-    void openBackgroundSettings();
+   // Сигнал о вставке нового алгоритмического элемента
+   void itemInserted(AlgorithmItem *item);
+   // Открывает диалог выбора объекта
+   void openObjectSelectDialog();
+   // Открывает настройки фона
+   void openBackgroundSettings();
 private:
     void createToolBox();
     void createActions();

--- a/diagramscene/algorithmitem.cpp
+++ b/diagramscene/algorithmitem.cpp
@@ -1,4 +1,4 @@
-#include "algoritmitem.h"
+#include "algorithmitem.h"
 
 #include "arrow.h"
 #include <QGraphicsScene>
@@ -8,16 +8,16 @@
 #include <QPen>
 
 // Creates algorithm item with connectors and title
-AlgoritmItem::AlgoritmItem(AlgoritmType diagramType, QMenu *contextMenu, QString title,
-                           QList<QPair<QString,QString>> in, QList<QPair<QString,QString>> out,
-                           QGraphicsItem *parent)
+AlgorithmItem::AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QString title,
+                             QList<QPair<QString,QString>> in, QList<QPair<QString,QString>> out,
+                             QGraphicsItem *parent)
     : QGraphicsItem(parent), myDiagramType(diagramType), myContextMenu(contextMenu)
 {
     QPainterPath path;
     const int spacing = 20; // vertical distance between ports
 
     titleItem = new QGraphicsTextItem(title, this);
-    QFont font = titleItem->font();
+    QFont font("Roboto", titleItem->font().pointSize());
     font.setBold(false);
     font.setUnderline(false);
     font.setPointSizeF(font.pointSizeF() * 0.8);
@@ -28,6 +28,7 @@ AlgoritmItem::AlgoritmItem(AlgoritmType diagramType, QMenu *contextMenu, QString
 
     for (auto pair : in) {
         auto inItem = new QGraphicsTextItem(pair.first + " (" + pair.second + ")", this);
+        inItem->setFont(QFont("Roboto"));
         inObjText.insert(pair, inItem);
         inTextsize = qMax(inTextsize, int(inItem->boundingRect().width()));
         auto inObj = new QGraphicsEllipseItem(0, 0, 10, 10, this);
@@ -37,6 +38,7 @@ AlgoritmItem::AlgoritmItem(AlgoritmType diagramType, QMenu *contextMenu, QString
     }
     for (auto pair : out) {
         auto outItem = new QGraphicsTextItem(pair.first + " (" + pair.second + ")", this);
+        outItem->setFont(QFont("Roboto"));
         outObjText.insert(pair, outItem);
         outTextsize = qMax(outTextsize, int(outItem->boundingRect().width()));
         auto outObj = new QGraphicsEllipseItem(0, 0, 10, 10, this);
@@ -58,7 +60,9 @@ AlgoritmItem::AlgoritmItem(AlgoritmType diagramType, QMenu *contextMenu, QString
     polygonItem = new QGraphicsPolygonItem(myPolygon, this);
     polygonItem->setZValue(-10);
     polygonItem->setPen(QPen(Qt::black, 1));
-    titleItem->setPos(-width / 2.0 + 5, -height / 2.0 + 10);
+    // Place title near the bottom with 10px offset
+    titleItem->setPos(-width / 2.0 + 5,
+                      height / 2.0 - titleItem->boundingRect().height() - 10);
 
     int i = 0;
     for (auto var : inObjCircle) {
@@ -87,28 +91,28 @@ AlgoritmItem::AlgoritmItem(AlgoritmType diagramType, QMenu *contextMenu, QString
 }
 
 // Removes arrow reference from list
-void AlgoritmItem::removeArrow(Arrow *arrow) {
+void AlgorithmItem::removeArrow(Arrow *arrow) {
     arrows.removeAll(arrow);
 }
 
 // Removes and deletes all arrows connected to this item
-void AlgoritmItem::removeArrows() {
+void AlgorithmItem::removeArrows() {
     const auto arrowsCopy = arrows;
     for (Arrow *arrow : arrowsCopy) {
-        static_cast<AlgoritmItem*>(arrow->startItem()->parentItem())->removeArrow(arrow);
-        static_cast<AlgoritmItem*>(arrow->endItem()->parentItem())->removeArrow(arrow);
+        static_cast<AlgorithmItem*>(arrow->startItem()->parentItem())->removeArrow(arrow);
+        static_cast<AlgorithmItem*>(arrow->endItem()->parentItem())->removeArrow(arrow);
         scene()->removeItem(arrow);
         delete arrow;
     }
 }
 
 // Adds arrow to internal list
-void AlgoritmItem::addArrow(Arrow *arrow) {
+void AlgorithmItem::addArrow(Arrow *arrow) {
     arrows.append(arrow);
 }
 
 // Returns pixmap representation for given type
-QPixmap AlgoritmItem::image(AlgoritmType type) {
+QPixmap AlgorithmItem::image(AlgorithmType type) {
     QPixmap pixmap(250, 250);
     switch (type) {
     case ALGORITM:
@@ -135,29 +139,29 @@ QPixmap AlgoritmItem::image(AlgoritmType type) {
 }
 
 // Sets fill brush color of polygon
-void AlgoritmItem::setBrush(QColor color) {
+void AlgorithmItem::setBrush(QColor color) {
     polygonItem->setBrush(color);
 }
 
 // Returns list of output connector circles
-QList<QGraphicsEllipseItem *> AlgoritmItem::getOutItems() {
+QList<QGraphicsEllipseItem *> AlgorithmItem::getOutItems() {
     return outObjCircle.values();
 }
 
 // Returns list of input connector circles
-QList<QGraphicsEllipseItem *> AlgoritmItem::getInItems() {
+QList<QGraphicsEllipseItem *> AlgorithmItem::getInItems() {
     return inObjCircle.values();
 }
 
 // Shows context menu for the item
-void AlgoritmItem::contextMenuEvent(QGraphicsSceneContextMenuEvent *event) {
+void AlgorithmItem::contextMenuEvent(QGraphicsSceneContextMenuEvent *event) {
     scene()->clearSelection();
     setSelected(true);
     myContextMenu->exec(event->screenPos());
 }
 
 // Updates arrows when item moves or selection changes
-QVariant AlgoritmItem::itemChange(GraphicsItemChange change, const QVariant &value) {
+QVariant AlgorithmItem::itemChange(GraphicsItemChange change, const QVariant &value) {
     if (change == QGraphicsItem::ItemPositionChange) {
         for (Arrow *arrow : qAsConst(arrows))
             arrow->updatePosition();
@@ -171,10 +175,10 @@ QVariant AlgoritmItem::itemChange(GraphicsItemChange change, const QVariant &val
 }
 
 // Bounding rectangle of the item
-QRectF AlgoritmItem::boundingRect() const {
+QRectF AlgorithmItem::boundingRect() const {
     return polygonItem->boundingRect();
 }
 
 // No custom painting required
-void AlgoritmItem::paint(QPainter *, const QStyleOptionGraphicsItem *, QWidget *) {
+void AlgorithmItem::paint(QPainter *, const QStyleOptionGraphicsItem *, QWidget *) {
 }

--- a/diagramscene/algorithmitem.h
+++ b/diagramscene/algorithmitem.h
@@ -1,5 +1,5 @@
-#ifndef ALGORITMITEM_H
-#define ALGORITMITEM_H
+#ifndef ALGORITHMITEM_H
+#define ALGORITHMITEM_H
 
 #include <QGraphicsItem>
 #include <QMap>
@@ -16,36 +16,37 @@ class QWidget;
 class Arrow;
 
 // Visual block representing an algorithm with input/output connectors
-class AlgoritmItem : public QGraphicsItem {
+class AlgorithmItem : public QGraphicsItem {
 public:
     enum { Type = UserType + 15 };
-    enum AlgoritmType { ALGORITM, CONDITION, EVENT, PARAM };
+    enum AlgorithmType { ALGORITM, CONDITION, EVENT, PARAM };
 
     // Constructs item with given type, context menu and connector lists
-    AlgoritmItem(AlgoritmType diagramType, QMenu *contextMenu, QString title = "",
-                 QList<QPair<QString,QString>> in = {},
-                 QList<QPair<QString,QString>> out = {},
-                 QGraphicsItem *parent = nullptr);
+    AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QString title = "",
+                  QList<QPair<QString,QString>> in = {},
+                  QList<QPair<QString,QString>> out = {},
+                  QGraphicsItem *parent = nullptr);
 
     // Removes a single arrow from this item
     void removeArrow(Arrow *arrow);
     // Deletes all arrows connected to the item
     void removeArrows();
     // Returns type of algorithm
-    AlgoritmType diagramType() const { return myDiagramType; }
+    AlgorithmType diagramType() const { return myDiagramType; }
     // Current polygon representing the item
     QPolygonF polygon() const { return myPolygon; }
     // Adds arrow to internal list
     void addArrow(Arrow *arrow);
     // Creates pixmap preview for specified type
-    QPixmap image(AlgoritmType type);
+    QPixmap image(AlgorithmType type);
     // QGraphicsItem type id
     int type() const override { return Type; }
     // Sets background brush color
     void setBrush(QColor);
 
-    // Lists of connector circles
+    // Returns output connector circles
     QList<QGraphicsEllipseItem *> getOutItems();
+    // Returns input connector circles
     QList<QGraphicsEllipseItem *> getInItems();
 
 protected:
@@ -55,7 +56,7 @@ protected:
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
 private:
-    AlgoritmType myDiagramType;
+    AlgorithmType myDiagramType;
     QPolygonF myPolygon;
     QMenu *myContextMenu{nullptr};
     QList<Arrow *> arrows;
@@ -74,4 +75,4 @@ public:
     void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 };
 
-#endif // ALGORITMITEM_H
+#endif // ALGORITHMITEM_H

--- a/diagramscene/diagramitem.h
+++ b/diagramscene/diagramitem.h
@@ -20,18 +20,28 @@ public:
     enum { Type = UserType + 15 };
     enum DiagramType { Step, Conditional, StartEnd, Io };
 
+    // Конструктор элемента диаграммы
     DiagramItem(DiagramType diagramType, QMenu *contextMenu, QGraphicsItem *parent = nullptr);
 
+    // Удаляет конкретную стрелку
     void removeArrow(Arrow *arrow);
+    // Удаляет все стрелки
     void removeArrows();
+    // Возвращает тип диаграммы
     DiagramType diagramType() const { return myDiagramType; }
+    // Возвращает текущий полигон
     QPolygonF polygon() const { return myPolygon; }
+    // Добавляет стрелку
     void addArrow(Arrow *arrow);
+    // Возвращает изображение элемента
     QPixmap image() const;
+    // Тип элемента
     int type() const override { return Type; }
 
 protected:
+    // Отображает контекстное меню
     void contextMenuEvent(QGraphicsSceneContextMenuEvent *event) override;
+    // Обрабатывает изменение положения
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
 private:

--- a/diagramscene/diagramscene.cpp
+++ b/diagramscene/diagramscene.cpp
@@ -17,7 +17,7 @@ DiagramScene::DiagramScene(QMenu *itemMenu, QObject *parent)
 {
     myItemMenu = itemMenu;
     myMode = MoveItem;
-    myItemType = AlgoritmItem::ALGORITM;
+    myItemType = AlgorithmItem::ALGORITM;
     line = nullptr;
     textItem = nullptr;
     myItemColor = Qt::white;
@@ -54,7 +54,7 @@ void DiagramScene::setItemColor(const QColor &color)
 {
     myItemColor = color;
     if (isItemChange(DiagramItem::Type)) {
-        AlgoritmItem *item = qgraphicsitem_cast<AlgoritmItem *>(selectedItems().first());
+        AlgorithmItem *item = qgraphicsitem_cast<AlgorithmItem *>(selectedItems().first());
         item->setBrush(myItemColor);
     }
 }
@@ -85,7 +85,7 @@ void DiagramScene::setMode(Mode mode)
 }
 
 // Устанавливает тип добавляемого алгоритмического элемента
-void DiagramScene::setItemType(AlgoritmItem::AlgoritmType type)
+void DiagramScene::setItemType(AlgorithmItem::AlgorithmType type)
 {
     myItemType = type;
 }
@@ -118,32 +118,32 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
     if (mouseEvent->button() != Qt::LeftButton)
         return;
 
-    AlgoritmItem *item;
+    AlgorithmItem *item;
     switch (myMode) {
         case InsertItem:{
             QString title = "";
             QList<QPair<QString,QString>> in;
             QList<QPair<QString,QString>> out;
             switch (myItemType) {
-            case AlgoritmItem::ALGORITM:
+            case AlgorithmItem::ALGORITM:
                 title = "Алгоритм";
                 in = {QPair<QString,QString> ("Lat","double"),QPair<QString,QString> ("Lon","double")};
                 out = {QPair<QString,QString> ("Lat","double"),QPair<QString,QString> ("Lon","double")};
                 myItemColor = QColor("#E3E3FD");
                 break;
-            case AlgoritmItem::CONDITION:{
+            case AlgorithmItem::CONDITION:{
                     title = "Условие";
                     QPair<QString,QString> f("SeeTarget","bool");
                     in.append(f);
                     out = {QPair<QString,QString> ("Lat","double"),QPair<QString,QString> ("Lon","double")};
                     myItemColor = QColor("#FFFFE3");
                 }break;
-            case AlgoritmItem::EVENT:
+            case AlgorithmItem::EVENT:
                 title = "Событие";
                 out = {QPair<QString,QString> ("SeeTarget","bool")};
                 myItemColor = QColor("#FFF9A3");
                 break;
-            case AlgoritmItem::PARAM:
+            case AlgorithmItem::PARAM:
                 title = "Параметры";
                 in = {QPair<QString,QString> ("Lat","double"),QPair<QString,QString> ("Lon","double")};
                 myItemColor = QColor("#CFFFE5");
@@ -151,7 +151,7 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
             default:
                 break;
             }
-            item = new AlgoritmItem(myItemType, myItemMenu,title,in,out);
+            item = new AlgorithmItem(myItemType, myItemMenu,title,in,out);
             item->setBrush(myItemColor);
             addItem(item);
             item->setPos(mouseEvent->scenePos());
@@ -233,8 +233,8 @@ void DiagramScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent)
 
             Arrow *arrow = new Arrow(startItem, endItem);
             arrow->setColor(myLineColor);
-            static_cast<AlgoritmItem*>(startItem->parentItem())->addArrow(arrow);
-            static_cast<AlgoritmItem*>(endItem->parentItem())->addArrow(arrow);
+            static_cast<AlgorithmItem*>(startItem->parentItem())->addArrow(arrow);
+            static_cast<AlgorithmItem*>(endItem->parentItem())->addArrow(arrow);
             addItem(arrow);
             arrow->updatePosition();
             emit lineInserted();
@@ -253,6 +253,7 @@ void DiagramScene::wheelEvent(QGraphicsSceneWheelEvent *mouseEvent)
         emit zoom(-1);
 }
 
+// Обрабатывает вход объекта при перетаскивании
 void DiagramScene::dragEnterEvent(QGraphicsSceneDragDropEvent *event)
 {
     if (event->mimeData()->hasFormat("application/x-algorithm"))
@@ -261,6 +262,7 @@ void DiagramScene::dragEnterEvent(QGraphicsSceneDragDropEvent *event)
         QGraphicsScene::dragEnterEvent(event);
 }
 
+// Обрабатывает перемещение объекта при перетаскивании
 void DiagramScene::dragMoveEvent(QGraphicsSceneDragDropEvent *event)
 {
     if (event->mimeData()->hasFormat("application/x-algorithm"))
@@ -269,6 +271,7 @@ void DiagramScene::dragMoveEvent(QGraphicsSceneDragDropEvent *event)
         QGraphicsScene::dragMoveEvent(event);
 }
 
+// Обрабатывает сброс объекта на сцену
 void DiagramScene::dropEvent(QGraphicsSceneDragDropEvent *event)
 {
     if (event->mimeData()->hasFormat("application/x-algorithm")) {
@@ -297,7 +300,7 @@ void DiagramScene::dropEvent(QGraphicsSceneDragDropEvent *event)
                     outParams.append({key, o.value(key).toString()});
                 }
             }
-            AlgoritmItem *item = new AlgoritmItem(AlgoritmItem::ALGORITM, myItemMenu, title, inParams, outParams);
+            AlgorithmItem *item = new AlgorithmItem(AlgorithmItem::ALGORITM, myItemMenu, title, inParams, outParams);
             item->setBrush(QColor("#E3E3FD"));
             addItem(item);
             item->setPos(event->scenePos());

--- a/diagramscene/diagramscene.h
+++ b/diagramscene/diagramscene.h
@@ -3,10 +3,9 @@
 
 #include "diagramitem.h"
 #include "diagramtextitem.h"
-#include <QDebug>
 #include <QGraphicsScene>
 #include <QGraphicsView>
-#include "algoritmitem.h"
+#include "algorithmitem.h"
 
 QT_BEGIN_NAMESPACE
 class QGraphicsSceneMouseEvent;
@@ -61,14 +60,14 @@ public slots:
     void setMode(Mode mode);
 
     // Устанавливает тип добавляемого алгоритмического элемента
-    void setItemType(AlgoritmItem::AlgoritmType type);
+    void setItemType(AlgorithmItem::AlgorithmType type);
 
     // Обрабатывает потерю фокуса текстовым редактором
     void editorLostFocus(DiagramTextItem *item);
 
 signals:
     // Сигнал о вставке нового элемента
-    void itemInserted(AlgoritmItem *item);
+    void itemInserted(AlgorithmItem *item);
     void textInserted(QGraphicsTextItem *item);
     void itemSelected(QGraphicsItem *item);
     void zoom(int i);
@@ -100,7 +99,7 @@ private:
     QPointF center;
     QPointF newCenter;
 
-    AlgoritmItem::AlgoritmType myItemType;
+    AlgorithmItem::AlgorithmType myItemType;
     QMenu *myItemMenu;
     Mode prevMode;
     Mode myMode;

--- a/diagramscene/diagramtextitem.h
+++ b/diagramscene/diagramtextitem.h
@@ -15,8 +15,10 @@ class DiagramTextItem : public QGraphicsTextItem
 public:
     enum { Type = UserType + 3 };
 
+    // Конструктор текстового элемента
     DiagramTextItem(QGraphicsItem *parent = nullptr);
 
+    // Тип элемента
     int type() const override { return Type; }
 
 signals:
@@ -24,8 +26,11 @@ signals:
     void selectedChange(QGraphicsItem *item);
 
 protected:
+    // Отслеживает изменения выделения
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
+    // Обрабатывает потерю фокуса
     void focusOutEvent(QFocusEvent *event) override;
+    // Включает редактирование по двойному клику
     void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
 };
 //! [0]

--- a/diagramscene/itemtoolbox.cpp
+++ b/diagramscene/itemtoolbox.cpp
@@ -11,23 +11,26 @@
 
 #include "../db_service/services/FileDataStorageService.h"
 
+// Создает тулбокс и заполняет дерево алгоритмов
 ItemToolBox::ItemToolBox(QWidget *parent) :
     QToolBox(parent),
     ui(new Ui::ItemToolBox),
-    algoritmTree(new QTreeWidget(this))
+    algorithmTree(new QTreeWidget(this))
 {
     ui->setupUi(this);
 
-    algoritmTree->setHeaderHidden(true);
-    addItem(algoritmTree, tr("Алгоритмы"));
+    algorithmTree->setHeaderHidden(true);
+    addItem(algorithmTree, tr("Алгоритмы"));
     loadAlgorithms();
 }
 
+// Деструктор
 ItemToolBox::~ItemToolBox()
 {
     delete ui;
 }
 
+// Загружает дерево алгоритмов из директории
 void ItemToolBox::loadAlgorithms()
 {
     QDir dir(QString(MAIN_DIR_DEFAULT) + SUB_DIR_ALGORITHMS);
@@ -54,7 +57,7 @@ void ItemToolBox::loadAlgorithms()
 
         QTreeWidgetItem *typeItem = nullptr;
         if (!typeItems.contains(type)) {
-            typeItem = new QTreeWidgetItem(algoritmTree);
+            typeItem = new QTreeWidgetItem(algorithmTree);
             typeItem->setText(0, type);
             typeItem->setIcon(0, folderIcon);
             typeItems.insert(type, typeItem);
@@ -79,5 +82,5 @@ void ItemToolBox::loadAlgorithms()
         algItem->setData(0, Qt::UserRole, info.absoluteFilePath());
     }
 
-    algoritmTree->expandAll();
+    algorithmTree->expandAll();
 }

--- a/diagramscene/itemtoolbox.h
+++ b/diagramscene/itemtoolbox.h
@@ -13,16 +13,19 @@ class ItemToolBox : public QToolBox
     Q_OBJECT
 
 public:
+    // Создает тулбокс с деревьями алгоритмов
     explicit ItemToolBox(QWidget *parent = nullptr);
+    // Освобождает ресурсы
     ~ItemToolBox();
 
 private:
+    // Загружает описания алгоритмов из файлов
     void loadAlgorithms();
 
     Ui::ItemToolBox *ui;
     QTreeWidget *eventTree = nullptr;
     QTreeWidget *conditionTree = nullptr;
-    QTreeWidget *algoritmTree = nullptr;
+    QTreeWidget *algorithmTree = nullptr;
     QTreeWidget *paramTree = nullptr;
 };
 


### PR DESCRIPTION
## Summary
- Rename AlgoritmItem to AlgorithmItem and update references
- Fix arrow start/end item access in DiagramSceneDlg
- Style algorithm container title and text with Roboto fonts and bottom offset
- Clean up diagramscene code and add missing comments

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt5Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b498549ca4832e9e0f6357d9e7da5d