### PR TITLE
Improve diagram scene interactions and visuals

### DIFF
--- a/diagramscene/DiagramSceneDlg.cpp
+++ b/diagramscene/DiagramSceneDlg.cpp
@@ -525,7 +525,7 @@ void DiagramSceneDlg::createToolBox()
     toolBox = new QToolBox;
     toolBox->setSizePolicy(QSizePolicy(QSizePolicy::Preferred, QSizePolicy::Ignored));
     toolBox->setMinimumWidth(200);
-    toolBox->addItem(itemWidget, tr("Основные блок-схемы"));
+    toolBox->addItem(itemWidget, tr("Элементы блок-схемы"));
     toolBox->addItem(algTree, tr("Доступные ИРЗ"));
 }
 

--- a/diagramscene/algorithmitem.cpp
+++ b/diagramscene/algorithmitem.cpp
@@ -15,6 +15,7 @@ AlgorithmItem::AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QStr
 {
     QPainterPath path;
     const int spacing = 20; // vertical distance between ports
+    const int titleMargin = 5; // top margin for title text
 
     titleItem = new QGraphicsTextItem(title, this);
     QFont font("Roboto", titleItem->font().pointSize());
@@ -53,35 +54,44 @@ AlgorithmItem::AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QStr
     if (width < inTextsize + outTextsize)
         width = inTextsize + outTextsize + 25;
     int h_size = qMax(in.size(), out.size());
-    int height = (h_size + 1) * (spacing + 10);
+
+    // Calculate total height: title + gap + connectors + bottom margin
+    const int topOffset = titleMargin + int(titleItem->boundingRect().height()) + 15;
+    const int bottomMargin = 20;
+    int height = topOffset + h_size * spacing + bottomMargin;
 
     path.addRoundedRect(-width / 2.0, -height / 2.0, width, height, 10, 10);
     myPolygon = path.toFillPolygon();
     polygonItem = new QGraphicsPolygonItem(myPolygon, this);
     polygonItem->setZValue(-10);
     polygonItem->setPen(QPen(Qt::black, 1));
-    // Place title near the bottom with 10px offset
-    titleItem->setPos(-width / 2.0 + 5,
-                      height / 2.0 - titleItem->boundingRect().height() - 10);
+
+    // Place title at the top
+    titleItem->setPos(-width / 2.0 + 5, -height / 2.0 + titleMargin);
 
     int i = 0;
     for (auto var : inObjCircle) {
-        var->setPos(-width / 2.0 + 5, -height / 2.0 + 20 + i * spacing);
+        const qreal y = -height / 2.0 + topOffset + i * spacing;
+        var->setPos(-width / 2.0 + 5, y);
         i++;
     }
     i = 0;
     for (auto var : inObjText) {
-        var->setPos(-width / 2.0 + 15, -height / 2.0 + 18 + i * spacing);
+        const qreal y = -height / 2.0 + topOffset + i * spacing;
+        var->setPos(-width / 2.0 + 15, y + 5 - var->boundingRect().height() / 2.0);
         i++;
     }
     i = 0;
     for (auto var : outObjCircle) {
-        var->setPos(width / 2.0 - 15, -height / 2.0 + 20 + i * spacing);
+        const qreal y = -height / 2.0 + topOffset + i * spacing;
+        var->setPos(width / 2.0 - 15, y);
         i++;
     }
     i = 0;
     for (auto var : outObjText) {
-        var->setPos(width / 2.0 - 15 - var->boundingRect().width(), -height / 2.0 + 18 + i * spacing);
+        const qreal y = -height / 2.0 + topOffset + i * spacing;
+        var->setPos(width / 2.0 - 15 - var->boundingRect().width(),
+                    y + 5 - var->boundingRect().height() / 2.0);
         i++;
     }
 

--- a/diagramscene/arrow.h
+++ b/diagramscene/arrow.h
@@ -38,7 +38,7 @@ private:
     QGraphicsEllipseItem *m_startItem{nullptr};
     QGraphicsEllipseItem *m_endItem{nullptr};
     QPolygonF arrowHead;
-    QColor myColor = Qt::white;
+    QColor myColor = Qt::darkGray;
 };
 
 #endif // ARROW_H

--- a/diagramscene/diagramscene.cpp
+++ b/diagramscene/diagramscene.cpp
@@ -22,7 +22,7 @@ DiagramScene::DiagramScene(QMenu *itemMenu, QObject *parent)
     textItem = nullptr;
     myItemColor = Qt::white;
     myTextColor = Qt::black;
-    myLineColor = QColor(100,149,237);
+    myLineColor = Qt::darkGray;
     center = sceneRect().center();
     // Устанавливаем фон "Сетка" по умолчанию
     setBackgroundBrush(QPixmap(":/images_diag/background2.png"));
@@ -108,13 +108,17 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
 {
     if (center.x()==0 && center.y()==0)
         center = sceneRect().center();
-    if (mouseEvent->button() == Qt::RightButton && mouseEvent->button() != Qt::LeftButton){
+
+    // Start scene dragging with right button or left button on empty space
+    if (mouseEvent->button() == Qt::RightButton ||
+        (mouseEvent->button() == Qt::LeftButton && myMode == MoveItem &&
+         !itemAt(mouseEvent->scenePos(), QTransform()))) {
         prevMode = myMode;
         myMode = MoveFullScene;
         beginMousePos = QCursor::pos();
-
         return;
     }
+
     if (mouseEvent->button() != Qt::LeftButton)
         return;
 
@@ -247,10 +251,16 @@ void DiagramScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent)
 // Обрабатывает прокрутку колесом мыши
 void DiagramScene::wheelEvent(QGraphicsSceneWheelEvent *mouseEvent)
 {
-    if (mouseEvent->delta()>0)
-        emit zoom(1);
-    else
-        emit zoom(-1);
+    if (mouseEvent->modifiers() & Qt::ControlModifier) {
+        if (mouseEvent->delta() > 0)
+            emit zoom(1);
+        else
+            emit zoom(-1);
+        mouseEvent->accept();
+    } else {
+        // Allow the view to perform default scrolling
+        mouseEvent->ignore();
+    }
 }
 
 // Обрабатывает вход объекта при перетаскивании


### PR DESCRIPTION
## Summary
- Place container titles at the top with spacing and align connector circles with parameter text
- Darken arrow color and keep arrows selectable for deletion
- Allow panning with left mouse drag on empty space and limit zooming to Ctrl+wheel, using wheel alone for scrolling
- Rename toolbox section to "Элементы блок-схемы"

## Testing
- `tests/run_tests.sh` *(fails: Could not find Qt5Config.cmake; executable ScenarioClientTests not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e7bde68832ea2d2cb3eaf4a35e6