### PR TITLE
Fix PropertyInfo initializer for QList append

### DIFF
--- a/diagramscene/DiagramSceneDlg.cpp
+++ b/diagramscene/DiagramSceneDlg.cpp
@@ -278,7 +278,7 @@ void DiagramSceneDlg::openObjectSelectDialog()
                     QString name = o["name"].toString();
                     QString ptitle = o["title"].toString(name);
                     QString type = o["type"].toString();
-                    props.append({ptitle, name, type, 0});
+                    props.append(AlgorithmItem::PropertyInfo{ptitle, name, type, 0});
                 }
                 break;
             }

--- a/diagramscene/algorithmitem.cpp
+++ b/diagramscene/algorithmitem.cpp
@@ -23,9 +23,9 @@ AlgorithmItem::AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QStr
     titleItem->setFont(font);
 
     for (auto &pair : in)
-        m_properties.append({pair.first, pair.first, pair.second, 1});
+        m_properties.append(PropertyInfo{pair.first, pair.first, pair.second, 1});
     for (auto &pair : out)
-        m_properties.append({pair.first, pair.first, pair.second, 2});
+        m_properties.append(PropertyInfo{pair.first, pair.first, pair.second, 2});
 
     polygonItem = new QGraphicsPolygonItem(this);
     polygonItem->setZValue(-10);


### PR DESCRIPTION
## Summary
- Use explicit PropertyInfo construction when appending to QList
- Ensure DiagramSceneDlg creates PropertyInfo instances explicitly

## Testing
- `./tests/run_tests.sh` (fails: Could not find Qt5)


------
https://chatgpt.com/codex/tasks/task_e_68b4a5374e94832e8ceafef81eae9467