### PR TITLE
Refine diagram item appearance and properties editor

### DIFF
--- a/diagramscene/PropertiesDialog.cpp
+++ b/diagramscene/PropertiesDialog.cpp
@@ -6,6 +6,8 @@
 #include <QVBoxLayout>
 #include <QDialogButtonBox>
 #include <QPushButton>
+#include <QLineEdit>
+#include <QColor>
 
 PropertiesDialog::PropertiesDialog(const QList<AlgorithmItem::PropertyInfo> &props, QWidget *parent)
     : QDialog(parent), m_table(new QTableWidget(props.size(), 4, this))
@@ -13,11 +15,36 @@ PropertiesDialog::PropertiesDialog(const QList<AlgorithmItem::PropertyInfo> &pro
     setWindowTitle(tr("Свойства"));
     QVBoxLayout *layout = new QVBoxLayout(this);
 
+    auto filterEdit = new QLineEdit(this);
+    filterEdit->setPlaceholderText(tr("Фильтр"));
+    layout->addWidget(filterEdit);
+
     QStringList headers;
     headers << "" << tr("Title") << tr("Name") << tr("Type");
     m_table->setHorizontalHeaderLabels(headers);
-    m_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     m_table->verticalHeader()->setVisible(false);
+
+    m_table->setStyleSheet(
+            "QTableView { border: 1px solid #444; gridline-color: #444;  }"
+            "QTableView:hover { border: 1px solid #444;  }"
+            "QTableView QLineEdit { background: transparent; border: none; }"
+            "QTableView QSpinBox { background: transparent; border: none; }"
+            "QTableView QComboBox { background: transparent; border: none; }"
+            "QTableView QDoubleSpinBox { background: transparent; border: none; }"
+            "QTableView QHeaderView::section {"
+            "  background-color: #2a2a2a;"
+            "  color: #aaa;"
+            "  padding: 4px 6px;"
+            "}"
+    );
+
+    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Interactive);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Interactive);
+    m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Interactive);
+    m_table->setColumnWidth(0, 100);
+    m_table->setColumnWidth(2, 180);
+    m_table->setColumnWidth(3, 100);
 
     int row = 0;
     for (const auto &p : props) {
@@ -28,8 +55,35 @@ PropertiesDialog::PropertiesDialog(const QList<AlgorithmItem::PropertyInfo> &pro
         m_table->setItem(row, 1, new QTableWidgetItem(p.title));
         m_table->setItem(row, 2, new QTableWidgetItem(p.name));
         m_table->setItem(row, 3, new QTableWidgetItem(p.type));
+
+        auto updateRow = [this, row]() {
+            auto combo = qobject_cast<QComboBox*>(m_table->cellWidget(row,0));
+            int dir = combo ? combo->currentIndex() : 0;
+            QColor bg = (dir == 0) ? Qt::transparent : QColor("#333");
+            QColor fg = (dir == 0) ? m_table->palette().text().color() : QColor("#fff");
+            for (int col = 1; col < m_table->columnCount(); ++col) {
+                if (auto item = m_table->item(row, col)) {
+                    item->setBackground(bg);
+                    item->setForeground(fg);
+                }
+            }
+            if (combo)
+                combo->setStyleSheet(dir == 0 ? "" : "QComboBox { background:#333; color:#fff; }");
+        };
+        updateRow();
+        connect(combo, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+                [updateRow](int){ updateRow(); });
+
         ++row;
     }
+
+    connect(filterEdit, &QLineEdit::textChanged, this, [this](const QString &text){
+        for (int row = 0; row < m_table->rowCount(); ++row) {
+            bool match = m_table->item(row,1)->text().contains(text, Qt::CaseInsensitive) ||
+                         m_table->item(row,2)->text().contains(text, Qt::CaseInsensitive);
+            m_table->setRowHidden(row, !match);
+        }
+    });
 
     layout->addWidget(m_table);
 
@@ -40,7 +94,7 @@ PropertiesDialog::PropertiesDialog(const QList<AlgorithmItem::PropertyInfo> &pro
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
     layout->addWidget(buttons);
 
-    resize(400, 300);
+    resize(800, 600);
 }
 
 QList<AlgorithmItem::PropertyInfo> PropertiesDialog::properties() const

--- a/diagramscene/algorithmitem.cpp
+++ b/diagramscene/algorithmitem.cpp
@@ -4,12 +4,11 @@
 #include <QGraphicsScene>
 #include <QGraphicsSceneContextMenuEvent>
 #include <QGraphicsSceneMouseEvent>
-#include <QGraphicsRectItem>
-#include <QGraphicsLineItem>
 #include <QMenu>
 #include <QPainter>
 #include <QPen>
 #include <QBrush>
+#include <QTextOption>
 
 // Creates algorithm item with connectors and title
 AlgorithmItem::AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QString title,
@@ -30,15 +29,7 @@ AlgorithmItem::AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QStr
     polygonItem = new QGraphicsPolygonItem(this);
     polygonItem->setZValue(-10);
     polygonItem->setPen(QPen(Qt::black, 1));
-
-    deleteButton = new QGraphicsRectItem(0, 0, 12, 12, this);
-    deleteButton->setBrush(Qt::white);
-    deleteButton->setPen(QPen(Qt::black, 1));
-    auto l1 = new QGraphicsLineItem(0, 0, 12, 12, deleteButton);
-    auto l2 = new QGraphicsLineItem(0, 12, 12, 0, deleteButton);
-    l1->setPen(QPen(Qt::black,1));
-    l2->setPen(QPen(Qt::black,1));
-    deleteButton->setVisible(false);
+    polygonItem->setBrush(QColor("#D3D3D3"));
 
     applyProperties();
 
@@ -131,10 +122,8 @@ QVariant AlgorithmItem::itemChange(GraphicsItemChange change, const QVariant &va
     } else if (change == QGraphicsItem::ItemSelectedHasChanged) {
         if (value.toBool()) {
             polygonItem->setPen(QPen(Qt::red, 2));
-            deleteButton->setVisible(true);
         } else {
             polygonItem->setPen(QPen(Qt::black, 1));
-            deleteButton->setVisible(false);
         }
     }
     return value;
@@ -142,16 +131,6 @@ QVariant AlgorithmItem::itemChange(GraphicsItemChange change, const QVariant &va
 
 void AlgorithmItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {
-    if (deleteButton && deleteButton->isVisible()) {
-        QPointF p = deleteButton->mapFromItem(this, event->pos());
-        if (deleteButton->boundingRect().contains(p)) {
-            removeArrows();
-            if (scene())
-                scene()->removeItem(this);
-            delete this;
-            return;
-        }
-    }
     QGraphicsItem::mousePressEvent(event);
 }
 
@@ -220,12 +199,15 @@ void AlgorithmItem::applyProperties()
     int height = topOffset + h_size * spacing + bottomMargin;
 
     QPainterPath path;
-    path.addRoundedRect(-width/2.0, -height/2.0, width, height, 10, 10);
+    path.addRect(-width/2.0, -height/2.0, width, height);
     myPolygon = path.toFillPolygon();
     polygonItem->setPolygon(myPolygon);
 
+    titleItem->setTextWidth(width - 10);
+    QTextOption opt = titleItem->document()->defaultTextOption();
+    opt.setAlignment(Qt::AlignCenter);
+    titleItem->document()->setDefaultTextOption(opt);
     titleItem->setPos(-width / 2.0 + 5, -height / 2.0 + titleMargin);
-    deleteButton->setPos(width/2.0 - deleteButton->boundingRect().width(), -height/2.0);
 
     int i = 0;
     for (auto var : inObjCircle) {

--- a/diagramscene/algorithmitem.h
+++ b/diagramscene/algorithmitem.h
@@ -12,7 +12,6 @@ class QGraphicsTextItem;
 class QGraphicsEllipseItem;
 class QGraphicsSceneContextMenuEvent;
 class QGraphicsSceneMouseEvent;
-class QGraphicsRectItem;
 class QPainter;
 class QStyleOptionGraphicsItem;
 class QWidget;
@@ -57,6 +56,11 @@ public:
         QString name;
         QString type;
         int direction = 0; // 0-none,1-in,2-out
+
+        PropertyInfo() { title = ""; name = ""; type = ""; direction = 0; }
+        PropertyInfo(QString t, QString n, QString tp, int d) {
+            title = t; name = n; type = tp; direction = d;
+        }
     };
 
     QList<PropertyInfo> properties() const { return m_properties; }
@@ -77,7 +81,6 @@ private:
 
     QGraphicsPolygonItem *polygonItem{nullptr};
     QGraphicsTextItem *titleItem{nullptr};
-    QGraphicsRectItem *deleteButton{nullptr};
     QMap<QPair<QString,QString>,QGraphicsEllipseItem *> inObjCircle;
     QMap<QPair<QString,QString>,QGraphicsEllipseItem *> outObjCircle;
     QMap<QPair<QString,QString>,QGraphicsTextItem *> inObjText;


### PR DESCRIPTION
## Summary
- add default and parameterized constructors to `PropertyInfo`
- simplify diagram item visuals: remove delete cross, use light gray rectangle with centered title
- enhance properties dialog with filtering, custom table styling, resizable columns and row highlighting

## Testing
- `tests/run_tests.sh` *(fails: Could not find Qt5 CMake package)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ab48551c832e83de25ef9962374d