### PR TITLE
Fix double deletion of connector in AlgorithmItem

### DIFF
--- a/diagramscene/algorithmitem.cpp
+++ b/diagramscene/algorithmitem.cpp
@@ -188,13 +188,13 @@ void AlgorithmItem::applyProperties()
     // clean previous connectors
     for (auto it : inObjCircle.values()) delete it;
     for (auto it : outObjCircle.values()) delete it;
-    if (selfOut) { delete selfOut; selfOut = nullptr; }
     for (auto it : inObjText.values()) delete it;
     for (auto it : outObjText.values()) delete it;
     inObjCircle.clear();
     outObjCircle.clear();
     inObjText.clear();
     outObjText.clear();
+    selfOut = nullptr;
 
     const int spacing = 20;
     const int titleMargin = 5;


### PR DESCRIPTION
## Summary
- prevent double deletion of `selfOut` in `AlgorithmItem::applyProperties`

## Testing
- `tests/run_tests.sh` *(fails: Could not find a package configuration file provided by "Qt5"*

------
https://chatgpt.com/codex/tasks/task_e_68b4bac4c1dc832e834534686b977e3b