### PR TITLE
Fix arrow drawing and algorithm color

### DIFF
--- a/diagramscene/DiagramSceneDlg.cpp
+++ b/diagramscene/DiagramSceneDlg.cpp
@@ -442,9 +442,9 @@ void DiagramSceneDlg::loadFromJson()
             props.append(p);
         }
         auto *item = new AlgorithmItem(AlgorithmItem::ALGORITM, itemMenu, title, {}, {});
-        item->setBrush(QColor("#D3D3D3"));
         item->setProperties(props);
         item->setIsObject(obj["is_object"].toBool());
+        item->setBrush(item->isObject() ? QColor("#D3D3D3") : QColor("#E3E3FD"));
         if (obj["self_out"].toBool())
             item->setObjectOutput(true);
         item->setPos(obj["x"].toDouble(), obj["y"].toDouble());

--- a/diagramscene/arrow.cpp
+++ b/diagramscene/arrow.cpp
@@ -53,8 +53,8 @@ void Arrow::paint(QPainter *painter, const QStyleOptionGraphicsItem *,
     const qreal offset = 15.0;
     qreal sr = m_startItem->rect().width() / 2.0;
     qreal er = m_endItem->rect().width() / 2.0;
-    QPointF startCenter = m_startItem->pos() + m_startItem->parentItem()->pos() + QPointF(sr, sr);
-    QPointF endCenter = m_endItem->pos() + m_endItem->parentItem()->pos() + QPointF(er, er);
+    QPointF startCenter = m_startItem->sceneBoundingRect().center();
+    QPointF endCenter = m_endItem->sceneBoundingRect().center();
 
     qreal startDir = (m_startItem->pos().x() < 0) ? -1 : 1;
     qreal endDir = (m_endItem->pos().x() < 0) ? -1 : 1;

--- a/diagramscene/diagramscene.cpp
+++ b/diagramscene/diagramscene.cpp
@@ -114,6 +114,8 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
         removeItem(line);
         delete line;
         line = nullptr;
+        if (parentView)
+            parentView->setMouseTracking(false);
         if (drawingArrow) {
             drawingArrow = false;
             myMode = prevMode;
@@ -140,6 +142,8 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
                     line = new QGraphicsLineItem(QLineF(centerPos, centerPos));
                     line->setPen(QPen(myLineColor, 2));
                     addItem(line);
+                    if (parentView)
+                        parentView->setMouseTracking(true);
                     return;
                 }
             }
@@ -378,6 +382,8 @@ void DiagramScene::addArrowFromLine(const QPointF &endPoint)
         myMode = prevMode;
         drawingArrow = false;
     }
+    if (parentView)
+        parentView->setMouseTracking(false);
 }
 
 // Проверяет, изменился ли элемент указанного типа


### PR DESCRIPTION
## Summary
- Prevent null-parent crashes in arrow painting
- Allow starting arrow connections from output handles with right-click cancel
- Restore algorithm item color when loading from JSON

## Testing
- `tests/run_tests.sh` *(fails: Could not find Qt5Config.cmake)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c4bf8e78832e97e58cfbc09a1832