### PR TITLE
Fix crash when updating algorithm item properties

### DIFF
--- a/diagramscene/algorithmitem.cpp
+++ b/diagramscene/algorithmitem.cpp
@@ -185,6 +185,9 @@ void AlgorithmItem::paint(QPainter *, const QStyleOptionGraphicsItem *, QWidget 
 
 void AlgorithmItem::applyProperties()
 {
+    // remove old arrows to avoid dangling pointers when connectors change
+    removeArrows();
+
     // clean previous connectors
     for (auto it : inObjCircle.values()) delete it;
     for (auto it : outObjCircle.values()) delete it;


### PR DESCRIPTION
## Summary
- Remove existing arrows before rebuilding connectors in `AlgorithmItem::applyProperties` to avoid dangling pointers

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt5Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c67cd704832e8480b49479e3b192