### PR TITLE
Add diagram scene save functionality

### DIFF
--- a/diagramscene/DiagramSceneDlg.cpp
+++ b/diagramscene/DiagramSceneDlg.cpp
@@ -362,60 +362,7 @@ void DiagramSceneDlg::saveToJson()
     QString fileName = QFileDialog::getSaveFileName(this, tr("Сохранить файл"), QString(), tr("JSON (*.json)"));
     if (fileName.isEmpty())
         return;
-
-    QJsonObject root;
-    QJsonArray itemsArr;
-    QList<AlgorithmItem*> itemsList;
-    const auto allItems = scene->items();
-    for (QGraphicsItem *gi : allItems) {
-        if (auto alg = qgraphicsitem_cast<AlgorithmItem*>(gi)) {
-            itemsList.append(alg);
-            QJsonObject obj;
-            obj["title"] = alg->title();
-            obj["x"] = alg->pos().x();
-            obj["y"] = alg->pos().y();
-            obj["self_out"] = alg->hasObjectOutput();
-            obj["is_object"] = alg->isObject();
-            QJsonArray props;
-            for (const auto &p : alg->properties()) {
-                QJsonObject po;
-                po["title"] = p.title;
-                po["name"] = p.name;
-                po["type"] = p.type;
-                po["direction"] = p.direction;
-                props.append(po);
-            }
-            obj["properties"] = props;
-            itemsArr.append(obj);
-        }
-    }
-    root["items"] = itemsArr;
-
-    QJsonArray arrowsArr;
-    for (QGraphicsItem *gi : allItems) {
-        if (gi->type() == Arrow::Type) {
-            Arrow *arr = static_cast<Arrow*>(gi);
-            AlgorithmItem *startAlg = qgraphicsitem_cast<AlgorithmItem*>(arr->startItem()->parentItem());
-            AlgorithmItem *endAlg = qgraphicsitem_cast<AlgorithmItem*>(arr->endItem()->parentItem());
-            int fromIndex = itemsList.indexOf(startAlg);
-            int toIndex = itemsList.indexOf(endAlg);
-            if (fromIndex >= 0 && toIndex >= 0) {
-                QJsonObject ao;
-                ao["from"] = fromIndex;
-                ao["to"] = toIndex;
-                ao["fromProp"] = startAlg->propertyNameForCircle(arr->startItem());
-                ao["toProp"] = endAlg->propertyNameForCircle(arr->endItem());
-                arrowsArr.append(ao);
-            }
-        }
-    }
-    root["arrows"] = arrowsArr;
-
-    QFile f(fileName);
-    if (f.open(QIODevice::WriteOnly)) {
-        f.write(QJsonDocument(root).toJson());
-        f.close();
-    }
+    scene->saveToFile(fileName);
 }
 
 void DiagramSceneDlg::loadFromJson()

--- a/diagramscene/diagramscene.h
+++ b/diagramscene/diagramscene.h
@@ -6,6 +6,7 @@
 #include <QGraphicsScene>
 #include <QGraphicsView>
 #include "algorithmitem.h"
+#include <QJsonObject>
 
 QT_BEGIN_NAMESPACE
 class QGraphicsSceneMouseEvent;
@@ -16,6 +17,7 @@ class QFont;
 class QGraphicsTextItem;
 class QColor;
 class QGraphicsSceneDragDropEvent;
+class QString;
 QT_END_NAMESPACE
 
 class DiagramScene : public QGraphicsScene
@@ -54,6 +56,12 @@ public:
 
     // Запоминает указатель на отображающий сцену виджет
     void setView(QGraphicsView *view);
+
+    // Возвращает JSON-объект с описанием элементов сцены
+    QJsonObject toJson() const;
+
+    // Сохраняет элементы сцены в указанный файл
+    bool saveToFile(const QString &fileName) const;
 
 public slots:
     // Меняет текущий режим работы сцены


### PR DESCRIPTION
## Summary
- Add JSON serialization methods to `DiagramScene` and allow saving to a file
- Simplify save action in `DiagramSceneDlg` to use new scene saving

## Testing
- `cmake -S . -B build` (fails: Could not find Qt5)

------
https://chatgpt.com/codex/tasks/task_e_68b4cc682820832ea13def58c01a1cc3