### PR TITLE
Add block element folder and colors to diagram editor

### DIFF
--- a/diagramscene/DiagramSceneDlg.cpp
+++ b/diagramscene/DiagramSceneDlg.cpp
@@ -44,52 +44,109 @@ protected:
             return;
         }
 
-        QString filePath = item->data(0, Qt::UserRole).toString();
-        QFile f(filePath);
-        if (!f.open(QIODevice::ReadOnly)) {
+        QVariant var = item->data(0, Qt::UserRole);
+        if (var.type() == QVariant::String) {
+            QString filePath = var.toString();
+            QFile f(filePath);
+            if (!f.open(QIODevice::ReadOnly)) {
+                QTreeWidget::startDrag(supportedActions);
+                return;
+            }
+            QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+            f.close();
+            QJsonObject obj = doc.object();
+
+            QString title = obj["title"].toString(item->text(0));
+            QList<QPair<QString,QString>> inParams;
+            QList<QPair<QString,QString>> outParams;
+            QJsonArray inArr = obj["input_parameters"].toArray();
+            for (const QJsonValue &val : inArr) {
+                QJsonObject o = val.toObject();
+                if (!o.isEmpty()) {
+                    QString key = o.keys().first();
+                    inParams.append({key, o.value(key).toString()});
+                }
+            }
+            QJsonArray outArr = obj["output_parameters"].toArray();
+            for (const QJsonValue &val : outArr) {
+                QJsonObject o = val.toObject();
+                if (!o.isEmpty()) {
+                    QString key = o.keys().first();
+                    outParams.append({key, o.value(key).toString()});
+                }
+            }
+
+            auto *temp = new AlgorithmItem(AlgorithmItem::ALGORITM, nullptr, title, inParams, outParams);
+            temp->setBrush(gDiagramColors.algorithmBackground);
+            QGraphicsScene tmpScene;
+            tmpScene.addItem(temp);
+            QRectF br = temp->boundingRect();
+            QPixmap pix(br.size().toSize());
+            pix.fill(Qt::transparent);
+            QPainter painter(&pix);
+            tmpScene.render(&painter, QRectF(), br);
+
+            QDrag *drag = new QDrag(this);
+            QMimeData *mimeData = new QMimeData;
+            mimeData->setData("application/x-algorithm", filePath.toUtf8());
+            drag->setMimeData(mimeData);
+            drag->setPixmap(pix);
+            drag->exec(Qt::CopyAction);
+        } else if (var.type() == QVariant::Int) {
+            int t = var.toInt();
+            QDrag *drag = new QDrag(this);
+            QMimeData *mimeData = new QMimeData;
+            QPixmap pix(100, 50);
+            pix.fill(Qt::transparent);
+
+            if (t == -1) {
+                mimeData->setData("application/x-diagram-text", QByteArray());
+                QGraphicsTextItem temp(item->text(0));
+                QGraphicsScene tmpScene;
+                tmpScene.addItem(&temp);
+                QRectF br = temp.boundingRect();
+                QPixmap tpix(br.size().toSize());
+                tpix.fill(Qt::transparent);
+                QPainter p(&tpix);
+                tmpScene.render(&p, QRectF(), br);
+                pix = tpix;
+            } else {
+                auto *temp = new AlgorithmItem(static_cast<AlgorithmItem::AlgorithmType>(t), nullptr, item->text(0));
+                switch (t) {
+                case AlgorithmItem::EVENT:
+                    temp->setBrush(gDiagramColors.eventBackground);
+                    break;
+                case AlgorithmItem::PARAM:
+                    temp->setBrush(gDiagramColors.paramBackground);
+                    break;
+                case AlgorithmItem::INPUT:
+                    temp->setBrush(gDiagramColors.inputDataBackground);
+                    break;
+                case AlgorithmItem::OUTPUT:
+                    temp->setBrush(gDiagramColors.outputDataBackground);
+                    break;
+                default:
+                    temp->setBrush(gDiagramColors.elementBackground);
+                    break;
+                }
+                QGraphicsScene tmpScene;
+                tmpScene.addItem(temp);
+                QRectF br = temp->boundingRect();
+                QPixmap tpix(br.size().toSize());
+                tpix.fill(Qt::transparent);
+                QPainter p(&tpix);
+                tmpScene.render(&p, QRectF(), br);
+                pix = tpix;
+                mimeData->setData("application/x-diagram-item", QByteArray::number(t));
+                mimeData->setText(item->text(0));
+            }
+
+            drag->setMimeData(mimeData);
+            drag->setPixmap(pix);
+            drag->exec(Qt::CopyAction);
+        } else {
             QTreeWidget::startDrag(supportedActions);
-            return;
         }
-        QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
-        f.close();
-        QJsonObject obj = doc.object();
-
-        QString title = obj["title"].toString(item->text(0));
-        QList<QPair<QString,QString>> inParams;
-        QList<QPair<QString,QString>> outParams;
-        QJsonArray inArr = obj["input_parameters"].toArray();
-        for (const QJsonValue &val : inArr) {
-            QJsonObject o = val.toObject();
-            if (!o.isEmpty()) {
-                QString key = o.keys().first();
-                inParams.append({key, o.value(key).toString()});
-            }
-        }
-        QJsonArray outArr = obj["output_parameters"].toArray();
-        for (const QJsonValue &val : outArr) {
-            QJsonObject o = val.toObject();
-            if (!o.isEmpty()) {
-                QString key = o.keys().first();
-                outParams.append({key, o.value(key).toString()});
-            }
-        }
-
-        auto *temp = new AlgorithmItem(AlgorithmItem::ALGORITM, nullptr, title, inParams, outParams);
-        temp->setBrush(gDiagramColors.algorithmBackground);
-        QGraphicsScene tmpScene;
-        tmpScene.addItem(temp);
-        QRectF br = temp->boundingRect();
-        QPixmap pix(br.size().toSize());
-        pix.fill(Qt::transparent);
-        QPainter painter(&pix);
-        tmpScene.render(&painter, QRectF(), br);
-
-        QDrag *drag = new QDrag(this);
-        QMimeData *mimeData = new QMimeData;
-        mimeData->setData("application/x-algorithm", filePath.toUtf8());
-        drag->setMimeData(mimeData);
-        drag->setPixmap(pix);
-        drag->exec(Qt::CopyAction);
     }
 };
 // Конструктор диалогового окна сцены
@@ -607,15 +664,48 @@ void DiagramSceneDlg::createToolBox()
     algTree->setHeaderHidden(true);
     algTree->setDragEnabled(true);
 
+    QIcon folderIcon = QApplication::style()->standardIcon(QStyle::SP_DirIcon);
+    QIcon fileIcon = QApplication::style()->standardIcon(QStyle::SP_FileIcon);
+
+    // Built-in diagram elements folder
+    QTreeWidgetItem *elementsRoot = new QTreeWidgetItem;
+    elementsRoot->setText(0, tr("Элементы блок схемы"));
+    elementsRoot->setIcon(0, folderIcon);
+    algTree->addTopLevelItem(elementsRoot);
+
+    QTreeWidgetItem *textItem = new QTreeWidgetItem(elementsRoot);
+    textItem->setText(0, tr("Текст"));
+    textItem->setIcon(0, fileIcon);
+    textItem->setData(0, Qt::UserRole, -1);
+
+    QTreeWidgetItem *eventItem = new QTreeWidgetItem(elementsRoot);
+    eventItem->setText(0, tr("Событие"));
+    eventItem->setIcon(0, fileIcon);
+    eventItem->setData(0, Qt::UserRole, static_cast<int>(AlgorithmItem::EVENT));
+
+    QTreeWidgetItem *inputItem = new QTreeWidgetItem(elementsRoot);
+    inputItem->setText(0, tr("Блок входных данных"));
+    inputItem->setIcon(0, fileIcon);
+    inputItem->setData(0, Qt::UserRole, static_cast<int>(AlgorithmItem::INPUT));
+
+    QTreeWidgetItem *outputItem = new QTreeWidgetItem(elementsRoot);
+    outputItem->setText(0, tr("Блок выходных данных"));
+    outputItem->setIcon(0, fileIcon);
+    outputItem->setData(0, Qt::UserRole, static_cast<int>(AlgorithmItem::OUTPUT));
+
+    QTreeWidgetItem *paramItem = new QTreeWidgetItem(elementsRoot);
+    paramItem->setText(0, tr("Блок параметров"));
+    paramItem->setIcon(0, fileIcon);
+    paramItem->setData(0, Qt::UserRole, static_cast<int>(AlgorithmItem::PARAM));
+
+    elementsRoot->setExpanded(true);
+
     QDir dir(QString(MAIN_DIR_DEFAULT) + SUB_DIR_ALGORITHMS);
     dir.setNameFilters({"*.json"});
     QFileInfoList files = dir.entryInfoList();
 
     QMap<QString, QTreeWidgetItem*> typeItems;
     QMap<QString, QMap<QString, QTreeWidgetItem*>> subTypeItems;
-
-    QIcon folderIcon = QApplication::style()->standardIcon(QStyle::SP_DirIcon);
-    QIcon fileIcon = QApplication::style()->standardIcon(QStyle::SP_FileIcon);
 
     for (const QFileInfo &info : files) {
         QFile f(info.absoluteFilePath());

--- a/diagramscene/algorithmitem.cpp
+++ b/diagramscene/algorithmitem.cpp
@@ -73,10 +73,16 @@ QPixmap AlgorithmItem::image(AlgorithmType type) {
         setBrush(gDiagramColors.elementBackground);
         break;
     case EVENT:
-        setBrush(gDiagramColors.elementBackground);
+        setBrush(gDiagramColors.eventBackground);
         break;
     case PARAM:
-        setBrush(gDiagramColors.elementBackground);
+        setBrush(gDiagramColors.paramBackground);
+        break;
+    case INPUT:
+        setBrush(gDiagramColors.inputDataBackground);
+        break;
+    case OUTPUT:
+        setBrush(gDiagramColors.outputDataBackground);
         break;
     default:
         pixmap.fill(Qt::transparent);

--- a/diagramscene/algorithmitem.h
+++ b/diagramscene/algorithmitem.h
@@ -21,7 +21,7 @@ class Arrow;
 class AlgorithmItem : public QGraphicsItem {
 public:
     enum { Type = UserType + 15 };
-    enum AlgorithmType { ALGORITM, CONDITION, EVENT, PARAM };
+    enum AlgorithmType { ALGORITM, CONDITION, EVENT, PARAM, INPUT, OUTPUT };
 
     // Constructs item with given type, context menu and connector lists
     AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QString title = "",

--- a/diagramscene/diagramcolors.h
+++ b/diagramscene/diagramcolors.h
@@ -6,6 +6,11 @@ struct DiagramColors {
     QColor algorithmBackground{QStringLiteral("#E3E3FD")};
     QColor objectBackground{QStringLiteral("#D3D3D3")};
     QColor elementBackground{QStringLiteral("#FFFFE3")};
+    QColor textBackground{Qt::white};
+    QColor eventBackground{QStringLiteral("#FDE3E3")};
+    QColor inputDataBackground{QStringLiteral("#E3FDE3")};
+    QColor outputDataBackground{QStringLiteral("#E3E3FD")};
+    QColor paramBackground{QStringLiteral("#FFF3E3")};
     QColor inputCircle{Qt::green};
     QColor outputCircle{QStringLiteral("#37a2d7")};
     QColor selfOutputCircle{QStringLiteral("#ffb400")};

--- a/diagramscene/diagramscene.cpp
+++ b/diagramscene/diagramscene.cpp
@@ -163,12 +163,22 @@ void DiagramScene::mousePressEvent(QGraphicsSceneMouseEvent *mouseEvent)
             case AlgorithmItem::EVENT:
                 title = "Событие";
                 out = {QPair<QString,QString> ("SeeTarget","bool")};
-                myItemColor = gDiagramColors.elementBackground;
+                myItemColor = gDiagramColors.eventBackground;
                 break;
             case AlgorithmItem::PARAM:
                 title = "Параметры";
                 in = {QPair<QString,QString> ("Lat","double"),QPair<QString,QString> ("Lon","double")};
-                myItemColor = gDiagramColors.elementBackground;
+                myItemColor = gDiagramColors.paramBackground;
+                break;
+            case AlgorithmItem::INPUT:
+                title = "Блок входных данных";
+                out = {QPair<QString,QString> ("Data","var")};
+                myItemColor = gDiagramColors.inputDataBackground;
+                break;
+            case AlgorithmItem::OUTPUT:
+                title = "Блок выходных данных";
+                in = {QPair<QString,QString> ("Data","var")};
+                myItemColor = gDiagramColors.outputDataBackground;
                 break;
             default:
                 break;
@@ -255,7 +265,9 @@ void DiagramScene::wheelEvent(QGraphicsSceneWheelEvent *mouseEvent)
 // Обрабатывает вход объекта при перетаскивании
 void DiagramScene::dragEnterEvent(QGraphicsSceneDragDropEvent *event)
 {
-    if (event->mimeData()->hasFormat("application/x-algorithm"))
+    if (event->mimeData()->hasFormat("application/x-algorithm") ||
+        event->mimeData()->hasFormat("application/x-diagram-item") ||
+        event->mimeData()->hasFormat("application/x-diagram-text"))
         event->acceptProposedAction();
     else
         QGraphicsScene::dragEnterEvent(event);
@@ -264,7 +276,9 @@ void DiagramScene::dragEnterEvent(QGraphicsSceneDragDropEvent *event)
 // Обрабатывает перемещение объекта при перетаскивании
 void DiagramScene::dragMoveEvent(QGraphicsSceneDragDropEvent *event)
 {
-    if (event->mimeData()->hasFormat("application/x-algorithm"))
+    if (event->mimeData()->hasFormat("application/x-algorithm") ||
+        event->mimeData()->hasFormat("application/x-diagram-item") ||
+        event->mimeData()->hasFormat("application/x-diagram-text"))
         event->acceptProposedAction();
     else
         QGraphicsScene::dragMoveEvent(event);
@@ -305,6 +319,68 @@ void DiagramScene::dropEvent(QGraphicsSceneDragDropEvent *event)
             item->setPos(event->scenePos());
             emit itemInserted(item);
         }
+        event->acceptProposedAction();
+    } else if (event->mimeData()->hasFormat("application/x-diagram-item")) {
+        int type = event->mimeData()->data("application/x-diagram-item").toInt();
+        QString title = event->mimeData()->text();
+        QList<QPair<QString,QString>> inParams;
+        QList<QPair<QString,QString>> outParams;
+        AlgorithmItem::AlgorithmType algType = static_cast<AlgorithmItem::AlgorithmType>(type);
+        switch (algType) {
+        case AlgorithmItem::EVENT:
+            title = title.isEmpty() ? QStringLiteral("Событие") : title;
+            outParams = {QPair<QString,QString>("SeeTarget","bool")};
+            break;
+        case AlgorithmItem::PARAM:
+            title = title.isEmpty() ? QStringLiteral("Параметры") : title;
+            inParams = {QPair<QString,QString>("Lat","double"), QPair<QString,QString>("Lon","double")};
+            break;
+        case AlgorithmItem::INPUT:
+            title = title.isEmpty() ? QStringLiteral("Блок входных данных") : title;
+            outParams = {QPair<QString,QString>("Data","var")};
+            break;
+        case AlgorithmItem::OUTPUT:
+            title = title.isEmpty() ? QStringLiteral("Блок выходных данных") : title;
+            inParams = {QPair<QString,QString>("Data","var")};
+            break;
+        default:
+            break;
+        }
+        AlgorithmItem *item = new AlgorithmItem(algType, myItemMenu, title, inParams, outParams);
+        switch (algType) {
+        case AlgorithmItem::EVENT:
+            item->setBrush(gDiagramColors.eventBackground);
+            break;
+        case AlgorithmItem::PARAM:
+            item->setBrush(gDiagramColors.paramBackground);
+            break;
+        case AlgorithmItem::INPUT:
+            item->setBrush(gDiagramColors.inputDataBackground);
+            break;
+        case AlgorithmItem::OUTPUT:
+            item->setBrush(gDiagramColors.outputDataBackground);
+            break;
+        default:
+            item->setBrush(gDiagramColors.elementBackground);
+            break;
+        }
+        addItem(item);
+        item->setPos(event->scenePos());
+        emit itemInserted(item);
+        event->acceptProposedAction();
+    } else if (event->mimeData()->hasFormat("application/x-diagram-text")) {
+        DiagramTextItem *txt = new DiagramTextItem();
+        txt->setFont(myFont);
+        txt->setTextInteractionFlags(Qt::TextEditorInteraction);
+        txt->setZValue(1000.0);
+        connect(txt, &DiagramTextItem::lostFocus,
+                this, &DiagramScene::editorLostFocus);
+        connect(txt, &DiagramTextItem::selectedChange,
+                this, &DiagramScene::itemSelected);
+        addItem(txt);
+        txt->setDefaultTextColor(myTextColor);
+        txt->setPos(event->scenePos());
+        emit textInserted(txt);
         event->acceptProposedAction();
     } else {
         QGraphicsScene::dropEvent(event);


### PR DESCRIPTION
## Summary
- Prepend "Элементы блок схемы" folder to algorithm tree with built-in items
- Support dragging text, event, input, output and parameter blocks
- Add distinct background colors for each block type in `DiagramColors`

## Testing
- `./tests/run_tests.sh` *(fails: could not find Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_68b55dd88a58832e98237c1f75168237