### PR TITLE
Add block element folder and colors to diagram editor

### DIFF
--- a/diagramscene/algorithmitem.cpp
+++ b/diagramscene/algorithmitem.cpp
@@ -70,13 +70,19 @@ QPixmap AlgorithmItem::image(AlgorithmType type) {
         setBrush(gDiagramColors.algorithmBackground);
         break;
     case CONDITION:
-        setBrush(gDiagramColors.elementBackground);
+        setBrush(gDiagramColors.conditionBackground);
         break;
     case EVENT:
-        setBrush(gDiagramColors.elementBackground);
+        setBrush(gDiagramColors.eventBackground);
         break;
     case PARAM:
-        setBrush(gDiagramColors.elementBackground);
+        setBrush(gDiagramColors.paramBackground);
+        break;
+    case INPUT:
+        setBrush(gDiagramColors.inputDataBackground);
+        break;
+    case OUTPUT:
+        setBrush(gDiagramColors.outputDataBackground);
         break;
     default:
         pixmap.fill(Qt::transparent);

--- a/diagramscene/algorithmitem.h
+++ b/diagramscene/algorithmitem.h
@@ -21,7 +21,7 @@ class Arrow;
 class AlgorithmItem : public QGraphicsItem {
 public:
     enum { Type = UserType + 15 };
-    enum AlgorithmType { ALGORITM, CONDITION, EVENT, PARAM };
+    enum AlgorithmType { ALGORITM, CONDITION, EVENT, PARAM, INPUT, OUTPUT };
 
     // Constructs item with given type, context menu and connector lists
     AlgorithmItem(AlgorithmType diagramType, QMenu *contextMenu, QString title = "",

--- a/diagramscene/diagramcolors.h
+++ b/diagramscene/diagramcolors.h
@@ -6,6 +6,12 @@ struct DiagramColors {
     QColor algorithmBackground{QStringLiteral("#E3E3FD")};
     QColor objectBackground{QStringLiteral("#D3D3D3")};
     QColor elementBackground{QStringLiteral("#FFFFE3")};
+    QColor textBackground{Qt::white};
+    QColor eventBackground{QStringLiteral("#FDE3E3")};
+    QColor conditionBackground{QStringLiteral("#E3F3FF")};
+    QColor inputDataBackground{QStringLiteral("#E3FDE3")};
+    QColor outputDataBackground{QStringLiteral("#E3E3FD")};
+    QColor paramBackground{QStringLiteral("#FFF3E3")};
     QColor inputCircle{Qt::green};
     QColor outputCircle{QStringLiteral("#37a2d7")};
     QColor selfOutputCircle{QStringLiteral("#ffb400")};


### PR DESCRIPTION
## Summary
- Prepend "Элементы блок схемы" folder to algorithm tree with built-in items
- Support dragging text, event, condition, input, output and parameter blocks
- Add distinct background colors for each block type in `DiagramColors`
- Fix double deletion when dragging text elements from the algorithm tree
- Ensure dragged text items show their label when dropped onto the canvas

## Testing
- `./tests/run_tests.sh` *(fails: Could not find Qt5)*

------
https://chatgpt.com/codex/tasks/task_e_68b55dd88a58832e98237c1f75168237