### PR TITLE
Fix object cleanup during scenario reload

### DIFF
--- a/db_service/ScenarioParser.cpp
+++ b/db_service/ScenarioParser.cpp
@@ -2,6 +2,7 @@
 #include "../models/Feature.h"
 #include <QFile>
 #include <QJsonArray>
+#include <QtAlgorithms>
 
 #include "../models/ActionModel.h"
 #include "../db_service/services/DataStorageServiceFactory.h"
@@ -17,12 +18,21 @@ bool ScenarioParser::loadScenario(const QString& filePath) {
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) return false;
 
+    qDeleteAll(m_objects);
     m_objects.clear();
+    qDeleteAll(m_classes);
     m_classes.clear();
+    qDeleteAll(m_interactions);
     m_interactions.clear();
+    qDeleteAll(m_algorithms);
     m_algorithms.clear();
+    qDeleteAll(m_files);
     m_files.clear();
+    qDeleteAll(m_features);
     m_features.clear();
+
+    delete m_simulation_parameters;
+    m_simulation_parameters = nullptr;
 
     QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
     m_rootJson = doc.object();


### PR DESCRIPTION
## Summary
- prevent dangling pointers during scenario reload by deleting existing objects, classes, interactions, algorithms, files, features and simulation parameters before parsing new scenario

## Testing
- `./tests/run_tests.sh` *(fails: Could not find a package configuration file provided by "Qt5" with any of the following names: Qt5Config.cmake, qt5-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b57b9b8b38832eb4db3d14c728103f