### PR TITLE
Avoid double deletion of child models on reload

### DIFF
--- a/db_service/ScenarioParser.cpp
+++ b/db_service/ScenarioParser.cpp
@@ -2,6 +2,7 @@
 #include "../models/Feature.h"
 #include <QFile>
 #include <QJsonArray>
+#include <QtAlgorithms>
 
 #include "../models/ActionModel.h"
 #include "../db_service/services/DataStorageServiceFactory.h"
@@ -17,12 +18,21 @@ bool ScenarioParser::loadScenario(const QString& filePath) {
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) return false;
 
+    qDeleteAll(m_objects);
     m_objects.clear();
+    qDeleteAll(m_classes);
     m_classes.clear();
+    qDeleteAll(m_interactions);
     m_interactions.clear();
+    qDeleteAll(m_algorithms);
     m_algorithms.clear();
+    qDeleteAll(m_files);
     m_files.clear();
+    qDeleteAll(m_features);
     m_features.clear();
+
+    delete m_simulation_parameters;
+    m_simulation_parameters = nullptr;
 
     QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
     m_rootJson = doc.object();

--- a/models/ActionModel.cpp
+++ b/models/ActionModel.cpp
@@ -9,7 +9,6 @@ ActionModel::ActionModel(QObject *parent) : QObject(parent)
 // Деструктор
 ActionModel::~ActionModel()
 {
-    qDeleteAll(m_outputMapping);
 }
 
 // Геттеры

--- a/models/AlgorithmModel.cpp
+++ b/models/AlgorithmModel.cpp
@@ -8,8 +8,6 @@ AlgorithmModel::AlgorithmModel(QObject *parent) : QObject(parent)
 
 AlgorithmModel::~AlgorithmModel()
 {
-    qDeleteAll(m_inputParameters);
-    qDeleteAll(m_outputParameters);
 }
 
 // Getters implementation

--- a/models/FeatureModel.cpp
+++ b/models/FeatureModel.cpp
@@ -4,9 +4,7 @@
 #include <QJsonArray>
 #include <QHBoxLayout>
 
-FeatureModel::~FeatureModel(){
-    qDeleteAll(m_properties);
-}
+FeatureModel::~FeatureModel(){}
 
 FeatureModel* FeatureModel::fromJson(const QJsonObject &json, QObject* parent){
     auto *model = new FeatureModel(parent);

--- a/models/ObjectScenarioModel.cpp
+++ b/models/ObjectScenarioModel.cpp
@@ -12,8 +12,6 @@ ObjectScenarioModel::ObjectScenarioModel(QObject *parent) : QObject(parent)
 
 ObjectScenarioModel::~ObjectScenarioModel()
 {
-    qDeleteAll(m_properties);
-    qDeleteAll(m_actions);
 }
 
 // Геттеры


### PR DESCRIPTION
## Summary
- remove manual deletion of parameter, action, feature and property lists so Qt's parent-child mechanism handles cleanup safely

## Testing
- `sudo apt-get update` *(fails: 403 Forbidden from repositories)*
- `./tests/run_tests.sh` *(fails: Could not find a package configuration file provided by "Qt5" with any of the following names: Qt5Config.cmake, qt5-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68b57b9b8b38832eb4db3d14c728103f